### PR TITLE
docs(uplinks): change text before properties table

### DIFF
--- a/docs/uplinks.md
+++ b/docs/uplinks.md
@@ -23,7 +23,7 @@ uplinks:
 ```
 ### Configuration
 
-You can define mutiple uplinks and each of them must have an unique name (key). They can have two properties:
+You can define mutiple uplinks and each of them must have an unique name (key). They can have the following properties:
 
 Property | Type | Required | Example | Support | Description | Default
 --- | --- | --- | --- | --- | --- | ---


### PR DESCRIPTION
I think there are more than just two properties for the uplinks configuration.