### PR TITLE
fix: use https to prevent mixed content warnings

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -3,7 +3,7 @@ id: docker
 title: Docker
 ---
 
-![alt Docker Pulls Count](http://dockeri.co/image/verdaccio/verdaccio "Docker Pulls Count")
+![alt Docker Pulls Count](https://dockeri.co/image/verdaccio/verdaccio "Docker Pulls Count")
 
 
 To pull the latest pre-built [docker image](https://hub.docker.com/r/verdaccio/verdaccio/):


### PR DESCRIPTION
There is an image which is loaded through `http` instead of `https` and throws a mixed content warning in environments (build, deployment, website).