### PR TITLE
chore: explicitely require from the docusaurus package

### DIFF
--- a/website/pages/en/help-with-translations.js
+++ b/website/pages/en/help-with-translations.js
@@ -7,11 +7,11 @@
 
 const React = require('react');
 
-const CompLibrary = require('../../core/CompLibrary.js');
+const CompLibrary = require('docusaurus/lib/core/CompLibrary.js');
 const Container = CompLibrary.Container;
 const GridBlock = CompLibrary.GridBlock;
 
-const translate = require('../../server/translate.js').translate;
+const translate = require('docusaurus/lib/server/translate.js').translate;
 
 const siteConfig = require(process.cwd() + '/siteConfig.js');
 

--- a/website/pages/en/help.js
+++ b/website/pages/en/help.js
@@ -7,8 +7,8 @@
 
 const React = require('react');
 
-const translate = require("../../server/translate.js").translate;
-const CompLibrary = require('../../core/CompLibrary.js');
+const translate = require("docusaurus/lib/server/translate.js").translate;
+const CompLibrary = require('docusaurus/lib/core/CompLibrary.js');
 const Container = CompLibrary.Container;
 const GridBlock = CompLibrary.GridBlock;
 

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -1,8 +1,8 @@
 const React = require('react');
 
-const CompLibrary = require('../../core/CompLibrary.js');
-const translate = require("../../server/translate.js").translate;
-const translation = require('../../server/translation.js');
+const CompLibrary = require('docusaurus/lib/core/CompLibrary.js');
+const translate = require("docusaurus/lib/server/translate.js").translate;
+const translation = require('docusaurus/lib/server/translation.js');
 const Container = CompLibrary.Container;
 const GridBlock = CompLibrary.GridBlock;
 

--- a/website/pages/en/team.js
+++ b/website/pages/en/team.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const CompLibrary = require('../../core/CompLibrary.js');
+const CompLibrary = require('docusaurus/lib/core/CompLibrary.js');
 const Container = CompLibrary.Container;
 const siteConfig = require(process.cwd() + '/siteConfig.js');
 

--- a/website/pages/en/users.js
+++ b/website/pages/en/users.js
@@ -1,7 +1,7 @@
 const React = require('react');
-const CompLibrary = require('../../core/CompLibrary.js');
+const CompLibrary = require('docusaurus/lib/core/CompLibrary.js');
 const Container = CompLibrary.Container;
-const translate = require("../../server/translate.js").translate;
+const translate = require("docusaurus/lib/server/translate.js").translate;
 
 const siteConfig = require(process.cwd() + '/siteConfig.js');
 

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -7,7 +7,7 @@
 
 const React = require('react');
 
-const CompLibrary = require('../../core/CompLibrary');
+const CompLibrary = require('docusaurus/lib/core/CompLibrary');
 
 const Container = CompLibrary.Container;
 


### PR DESCRIPTION
The current recommendation of the Docusaurus docs to use `../../` is an antipattern imo.
Directly using the right require path should be the way to go.

Docusaurus will use `docusaurus/CompLib` in v2 https://github.com/facebook/Docusaurus/issues/570#issuecomment-470206537

> Closing due to inactivity. Will do this in v2 like ‘import CompLib from “docusaurus/CompLib”’