### PR TITLE
docs: fix scope example for the web UI config (fixes #133)

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -30,7 +30,7 @@ gravatar | boolean | No | true | `>v4` | Gravatars will be generated under the h
 sort_packages | [asc,desc] | No | asc | `>v4` | By default private packages are sorted by ascending
 logo | string | No | `/local/path/to/my/logo.png` `http://my.logo.domain/logo.png` | all | a URI where logo is located (header logo)
 primary_color | string | No | "#4b5e40" | `>4` | The primary color to use throughout the UI (header, etc)
-scope | string | No | \\@myscope | `>v3.x` | If you're using this registry for a specific module scope, specify that scope to set it in the webui instructions header (note: escape @ with \\@)
+scope | string | No | @myscope | `>v3.x` | If you're using this registry for a specific module scope, specify that scope to set it in the webui instructions header
 
 
 > It is recommended the logo size has the following size `40x40` pixels.


### PR DESCRIPTION
Since v4 escaping of the scope is not needed anymore.