### PR TITLE
reference docker.yaml instead of full.yaml

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -58,11 +58,11 @@ You can customize the Verdaccio configuration using a Kubernetes *configMap*.
 
 #### Prepare
 
-Copy the [existing configuration](https://github.com/verdaccio/verdaccio/blob/master/conf/full.yaml)
+Copy the [existing configuration](https://github.com/verdaccio/verdaccio/blob/master/conf/docker.yaml)
 and adapt it for your use case:
 
 ```bash
-wget https://raw.githubusercontent.com/verdaccio/verdaccio/master/conf/full.yaml -O config.yaml
+wget https://raw.githubusercontent.com/verdaccio/verdaccio/master/conf/docker.yaml -O config.yaml
 ```
 
 **Note:** Make sure you are using the right path for the storage that is used for


### PR DESCRIPTION
The `full.yaml` file no longer contains any configuration. This PR updates the Kubernetes docs to reference the `docker.yaml` file instead.