### PR TITLE
docs(website): Docker support for website

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM node:lts
 
 # Create the docs website directory
-WORKDIR /website
+WORKDIR /verdaccio-website
 
 COPY . .
 
-WORKDIR /website/website
+WORKDIR /verdaccio-website/website
 
 RUN yarn install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:latest
+
+# Create the docs website directory
+WORKDIR /website
+
+COPY . .
+
+WORKDIR /website/website
+
+RUN npm install
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:lts
 
 # Create the docs website directory
 WORKDIR /website
@@ -7,8 +7,8 @@ COPY . .
 
 WORKDIR /website/website
 
-RUN npm install
+RUN yarn install
 
 EXPOSE 3000
 
-CMD ["npm", "start"]
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -14,19 +14,20 @@ Documentation files are hosted under `/docs` folder.
 You should run all these tasks from the inner `/website` folder.
 
 The commands you need to use for serving the site locally:
-- `npm install` - installs all dependencies.
-- `npm start` - runs a local server that launches the Verdaccio documentation site on http://localhost:3000/
+- `yarn install` - installs all dependencies.
+- `yarn start` - runs a local server that launches the Verdaccio documentation site on http://localhost:3000/
 
-# Running the website as a docker container
+# Running the website as a Docker container 
 
-The Verdaccio documentation website can run as a docker container (useful for offline stations, local serve of docs, etc.).
+The Verdaccio documentation website can run as a Docker container
+(useful for offline usage of the website).
  
- In order to run the website on docker, use the following commands (run commands from the outer **/website** folder):
+ In order to run the website on Docker, use the following commands (run commands from the outer **/website** folder):
 
 `docker build -t verdaccio-docs:4.0.1 . `- building the verdaccio documentation site image
 `docker run -p <host-port>:3000 verdaccio-docs:4.0.1 `- starting the container, listening on **<host-port>** for your choice.
 
-Saving the image for later offline usage is available by building the container and then using `sudo docker save verdaccio-docs:4.0.1 > <tar-name>.tar` and loading it afterwards with `sudo docker load < <tar-name>.tar `.
+Saving the image for later offline usage is available by building the container and then using `docker save verdaccio-docs:4.0.1 > <tar-name>.tar` and loading it afterwards with `docker load < <tar-name>.tar `.
 > tested on ubuntu 18.04.2 with Docker 18.09.6
 
 # Translation

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Verdaccio documentation website can run as a Docker container
  
  In order to run the website on Docker, use the following commands (run commands from the outer **/website** folder):
 
-`docker build -t verdaccio-docs:4.0.1 . `- building the verdaccio documentation site image
+`docker build -t verdaccio-docs:4.0.1 . `- building the Verdaccio documentation site image
 `docker run -p <host-port>:3000 verdaccio-docs:4.0.1 `- starting the container, listening on **<host-port>** for your choice.
 
 Saving the image for later offline usage is available by building the container and then using `docker save verdaccio-docs:4.0.1 > <tar-name>.tar` and loading it afterwards with `docker load < <tar-name>.tar `.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ https://www.verdaccio.org
 
 Documentation files are hosted under `/docs` folder.
 
+# Running the website locally
+You should run all these tasks from the inner `/website` folder.
+
+The commands you need to use for serving the site locally:
+- `npm install` - installs all dependencies.
+- `npm start` - runs a local server that launches the Verdaccio documentation site on http://localhost:3000/
+
+# Running the website as a docker container
+
+The Verdaccio documentation website can run as a docker container (useful for offline stations, local serve of docs, etc.).
+ 
+ In order to run the website on docker, use the following commands (run commands from the outer **/website** folder):
+
+`docker build -t verdaccio-docs:4.0.1 . `- building the verdaccio documentation site image
+`docker run -p <host-port>:3000 verdaccio-docs:4.0.1 `- starting the container, listening on **<host-port>** for your choice.
+
+Saving the image for later offline usage is available by building the container and then using `sudo docker save verdaccio-docs:4.0.1 > <tar-name>.tar` and loading it afterwards with `sudo docker load < <tar-name>.tar `.
+> tested on ubuntu 18.04.2 with Docker 18.09.6
+
 # Translation
 
 Verdaccio is powered by [crowdin](https://crowdin.com/project/verdaccio) platform that provides Verdaccio [a free open source license](https://crowdin.com/page/open-source-project-setup-request).


### PR DESCRIPTION
Added Docker support - The site can now be launched as a docker container:
* dockerfile & dockerignore are added
* readme changes, update for running as a container information
* running as a container provides offline support for Verdaccio docs site
