### PR TITLE
Update docs to include --info

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,7 @@ Command | Default | Example | Description
 --- | --- | --- | ---
 --listen \ **-l** | 4873 |  -p 7000 | http port
 --config \ **-c** | ~/.local/verdaccio/config.yaml | ~./config.yaml | the configuration file
+--info | | | prints local environment information
 
 ## Default config file location
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,7 +15,7 @@ Command | Default | Example | Description
 --- | --- | --- | ---
 --listen \ **-l** | 4873 |  -p 7000 | http port
 --config \ **-c** | ~/.local/verdaccio/config.yaml | ~./config.yaml | the configuration file
---info | | | prints local environment information
+--info \ **-i** | | | prints local environment information
 
 ## Default config file location
 


### PR DESCRIPTION
[#1365](https://github.com/verdaccio/verdaccio/pull/1365) brings about a new `--info` option which prints useful information concerning the local environment.