### PR TITLE
chore: use node slim image to reduce size in local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:lts-slim
 
 # Create the docs website directory
 WORKDIR /verdaccio-website


### PR DESCRIPTION
At the moment of writing this PR, the sizes of Node images are:
- **node:lts** -> _904MB_
- **node:lts-slim** -> _148MB_
- **node:lts-alpine** -> _75.3MB_

Currently, we are using **node:lts** for running the website in a local dev environment (or as local docs), but the base image size is really big for users that don't have a high speed connections (and it's a metered connections killer).
I want to migrate to **node:lts-alpine** as is the smaller one, but we have to install some utilities needed to build the site that doesn't come with the base image but, until I make some PoCs and see if users can benefit of that image, I prefer to provide users **node:lts-slim** base image as it's less than double of **node:lts-alpine** size and it's fully capable to run the site correctly.

**EDIT:** After some changes, the size of the image generated with **node:lts-alpine** base image is _243MB_, and **node:lts-slim** is _293MB_, so we can try using **alpine** version and change with slim if necessary.