### PR TITLE
chore: use node alpine image to reduce size in local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM node:lts
+FROM node:lts-alpine
 
 # Create the docs website directory
-WORKDIR /verdaccio-website
-
-COPY . .
+COPY . /verdaccio-website
 
 WORKDIR /verdaccio-website/website
 
-RUN yarn install
+RUN apk add --no-cache -t build-deps make gcc g++ python libtool autoconf automake && \
+    yarn install && \
+    apk del build-deps
 
 EXPOSE 3000
 


### PR DESCRIPTION
At the moment of writing this PR, the sizes of Node images are:
- **node:lts** -> _904MB_
- **node:lts-slim** -> _148MB_
- **node:lts-alpine** -> _75.3MB_

Currently, we are using **node:lts** for running the website in a local dev environment (or as local docs), but the base image size is really big for users that don't have a high speed connections (and it's a metered connections killer).
I want to migrate to **node:lts-alpine** as is the smaller one, but we have to install some utilities needed to install project dependencies that don't come with the base image but **node:lts-slim** base image contains.
Comparing the best two options, **slim vs alpine**, the size of the image generated with **node:lts-alpine** base image is _243MB_, and **node:lts-slim** is _293MB_, so we can try using **alpine** version and change with **slim** if necessary.