### PR TITLE
reverse-proxy.md: Apache example ProxyPass{Reverse} directive missing trailing slash

### DIFF
--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -34,8 +34,8 @@ Apache virtual server configuration
         ProxyRequests           Off
         ProxyPreserveHost       On
         AllowEncodedSlashes     NoDecode
-        ProxyPass               /       http://127.0.0.1:4873 nocanon
-        ProxyPassReverse        /       http://127.0.0.1:4873
+        ProxyPass               /       http://127.0.0.1:4873/ nocanon
+        ProxyPassReverse        /       http://127.0.0.1:4873/
     </VirtualHost>
     </IfModule>
 ````


### PR DESCRIPTION
Apache 2.4.39 reverse proxy virtual host configuration fails if ProxyPass{Reverse}'s `url` parameter is missing the trailing slash.