### PR TITLE
updated readme: Added Apollo GraphQL 

### DIFF
--- a/docs/who-is-using.md
+++ b/docs/who-is-using.md
@@ -20,6 +20,7 @@ title: "Who is using Verdaccio?"
 * [Mozilla Neutrino](https://neutrinojs.org/)
 * [create-react-app](https://github.com/facebook/create-react-app/blob/master/CONTRIBUTING.md#contributing-to-e2e-end-to-end-tests)
 * [Gatsby](https://github.com/gatsbyjs/gatsby)
+* [Apollo GraphQL](https://github.com/apollographql)
 * [Uppy](https://github.com/transloadit/uppy)
 * [Aurelia Framework](https://github.com/aurelia)
 * [bit](https://github.com/teambit/bit)


### PR DESCRIPTION
**Type:** Refactor

**The following has been addressed in the PR:** there is no issue

**Description:**

Apollo GraphQL now uses Verdaccio 👏😀 So I have added this information in the section "Who is using verdaccio"