### PR TITLE
docs(website): use the correct working directory path

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -73,7 +73,7 @@ Verdaccio 4 provides a new set of environment variables to modify either permiss
 
 Property | default | Description
 --- | --- | ---
-VERDACCIO_APPDIR | `/opt/verdaccio-build` | the docker working directory
+VERDACCIO_APPDIR | `/opt/verdaccio` | the docker working directory
 VERDACCIO_USER_NAME | `verdaccio` | the system user
 VERDACCIO_USER_UID | `10001` | the user id being used to apply folder permissions
 VERDACCIO_PORT | `4873` | the verdaccio port


### PR DESCRIPTION
The VERDACCIO_APPDIR is `/opt/verdaccio`, see https://github.com/verdaccio/verdaccio/blob/287ed3f88c899411839cdbea3e41ca10b528ca97/Dockerfile#L27