### PR TITLE
Add link to hertzg/docker-verdaccio-multiarch

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -197,6 +197,7 @@ There is a separate repository that hosts multiple configurations to compose Doc
 
 > If you have made an image based on Verdaccio, feel free to add it to this list.
 
+* [docker-verdaccio-multiarch](https://github.com/hertzg/docker-verdaccio-multiarch) Multiarch image mirrors
 * [docker-verdaccio-gitlab](https://github.com/snics/docker-verdaccio-gitlab)
 * [docker-verdaccio](https://github.com/deployable/docker-verdaccio)
 * [docker-verdaccio-s3](https://github.com/asynchrony/docker-verdaccio-s3) Private NPM container that can backup to s3


### PR DESCRIPTION
Hello, I've recenly setup a repository to auto build multiarch docker images of verdaccio using buildx and thought the documentation would find it useful.

Currently the images are buildt only for `amd64`  arch and can not be run on Raspberry Pi (`arm`), this repository adds support for multiarch images which include `arm` builds.