### PR TITLE
Fixed typo for plugins documentation

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -58,7 +58,7 @@ auth:
 
 #### Multiple Authentication plugins
 
-This is tecnically possible, making the plugin order important, as the credentials will be resolved in order.
+This is technically possible, making the plugin order important, as the credentials will be resolved in order.
 
 ```yaml
 auth:


### PR DESCRIPTION
Changed `This is tecnically possible, making the plugin order important, as the credentials will be resolved in order.` to `This is technically possible, making the plugin order important, as the credentials will be resolved in order.` :)