### PR TITLE
docs(web): removed deprecated codefund div

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -9,8 +9,6 @@ into some issues. The `npm login` command is designed to be used interactively. 
 issue in CI, scripts, etc. Below are some articles detailing how to use `npm login` on different
 CI platforms.
 
-<div id="codefund">''</div>
-
 - [Travis CI](https://remysharp.com/2015/10/26/using-travis-with-private-npm-deps)
 - [Circle CI 1.0](https://circleci.com/docs/1.0/npm-login/) or [Circle CI 2.0](https://circleci.com/docs/2.0/deployment-integrations/#npm)
 - [Gitlab CI](https://www.exclamationlabs.com/blog/continuous-deployment-to-npm-using-gitlab-ci/)

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,8 +7,6 @@ This file is the cornerstone of verdaccio where you can modify the default behav
 
 A default configuration file `config.yaml` is created the very first time you run `verdaccio`.
 
-<div id="codefund">''</div>
-
 ## Default Configuration
 
 The default configuration has support for **scoped** packages and allow any user to access all packages but only **authenticated users to publish**.

--- a/docs/dev-plugins.md
+++ b/docs/dev-plugins.md
@@ -13,8 +13,6 @@ There are many ways to extend `verdaccio`, the kind of plugins supported are:
 
 > We recommend developing plugins using our [Typescript type definitions](https://github.com/verdaccio/monorepo/tree/master/core/types).
 
-<div id="codefund">''</div>
-
 # Other plugins
 
 The following plugins are valid and in process of incubation.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,8 +14,6 @@ docker pull verdaccio/verdaccio
 
 ![Docker pull](assets/docker_verdaccio.gif)
 
-<div id="codefund">''</div>
-
 ## Tagged Versions
 
 Since version `v2.x` you can pull docker images by [tag](https://hub.docker.com/r/verdaccio/verdaccio/tags/), as follows:

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -5,8 +5,6 @@ title: "End to End testing"
 
 Some projects organize packages in multi-packages repositories or [monorepos](https://github.com/babel/babel/blob/master/doc/design/monorepo.md). E2E testing is a topic that usually is only relevant for User Interfaces, but from a Node.js perspective, **publishing packages also need to be tested**.
 
-<div id="codefund">''</div>
-
 <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Solution: a local npm registry. <a href="https://t.co/kvcyVANVSK">https://t.co/kvcyVANVSK</a></p>&mdash; Dan Abramov (@dan_abramov) <a href="https://twitter.com/dan_abramov/status/951427674844680192?ref_src=twsrc%5Etfw">11 de enero de 2018</a></blockquote>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -5,8 +5,6 @@ title: "GitHub Actions"
 
 With [GitHub Actions](https://github.com/features/actions) you can automate your workflow, each GitHub Action performs a specific step in a process.
 
-<div id="codefund">''</div>
-
 ![actions](/img/github-actions.png)
 
 ## Testing your packages

--- a/docs/iis-server.md
+++ b/docs/iis-server.md
@@ -25,8 +25,6 @@ npm install
 * Make sure you have an inbound rule accepting TCP traffic to the port in Windows Firewall
 * Thats it! Now you can navigate to the host and port that you specified
 
-<div id="codefund">''</div>
-
 I wanted the `verdaccio` site to be the default site in IIS so I did the following:
 
 * I stopped the "Default Web Site" and only start the site "verdaccio" site in IIS

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,8 +17,6 @@ Verdaccio is a multiplatform web application. To install it, you need a few basi
 
 > Verdaccio will support latest Node.js version according the [Node.js Release Working Group](https://github.com/nodejs/Release) recomendations.
 
-<div id="codefund">''</div>
-
 ## Installing the CLI
 
 `verdaccio` must be installed globaly using either of the following methods:

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -10,8 +10,6 @@ cluster is to use [Helm](https://helm.sh). Helm is a
 [Kubernetes](https://kubernetes.io) package manager which bring multiple
 advantages.
 
-<div id="codefund">''</div>
-
 ## Helm
 
 ### Setup Helm

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -13,8 +13,6 @@ uplinks:
 
 You can link multiple registries, the following document will drive you through some helpful configurations.
 
-<div id="codefund">''</div>
-
 ## Using Associating Scope
 
 The unique way to access multiple registries using the `.npmrc` is the scope feature as follows:

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -5,8 +5,6 @@ title: "Logger"
 
 As any web application, verdaccio has a customisable built-in logger. You can define multiple types of outputs.
 
-<div id="codefund">''</div>
-
 ```yaml
 logs:
   # console output

--- a/docs/logo.md
+++ b/docs/logo.md
@@ -12,8 +12,6 @@ won the [contest](https://github.com/verdaccio/verdaccio/issues/237)
 Special thanks to *[@Lisapressmar](https://github.com/Lisapressmar)* for her contribution
 with multiple image formats and sizes.
 
-<div id="codefund">''</div>
-
 ## Symbols
 
 __With text__

--- a/docs/node-api.md
+++ b/docs/node-api.md
@@ -7,8 +7,6 @@ Verdaccio can be invoked programmatically. The node API was introduced after ver
 
 ## Usage
 
-<div id="codefund">''</div>
-
 #### Programmatically
 
 ```js

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -8,8 +8,6 @@ webhooks, but will also deliver a simple payload to
 any endpoint. Currently only active for `npm publish`
 command.
 
-<div id="codefund">''</div>
-
 ## Usage
 
 An example with a **HipChat**, **Stride** and **Google Hangouts Chat** hook:

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -7,8 +7,6 @@ It's a series of contraints that allow or restrict access to the local storage b
 
 The security constraints remain on the shoulders of the plugin being used, by default `verdaccio` uses the [htpasswd plugin](https://github.com/verdaccio/verdaccio-htpasswd). If you use a different plugin the behaviour might be different. The default plugin does not handle `allow_access` and `allow_publish` by itself, it uses an internal fallback in case the plugin is not ready for it.
 
-<div id="codefund">''</div>
-
 For more information about permissions visit [the authentification section in the wiki](auth.md).
 
 ### Usage

--- a/docs/plugin-auth.md
+++ b/docs/plugin-auth.md
@@ -8,8 +8,6 @@ title: "Authentication Plugin"
 Is a sort plugin that allows to handle who access or publish to a specific package. By default the `htpasswd` is built-in, but can
 easily be replaced by your own.
 
-<div id="codefund">''</div>
-
  ## Getting Started
 
 The authentication plugins are defined in the `auth:` section, as follows:

--- a/docs/plugin-generator.md
+++ b/docs/plugin-generator.md
@@ -23,8 +23,6 @@ npm i -g generator-verdaccio-plugin
 
 Use `yeoman` is quite straighforward, you can read more infomation about it [here](https://yeoman.io/learning/index.html).
 
-<div id="codefund">''</div>
-
 After a success install, run `yo verdaccio-plugin` in your terminal and follow the steps.
 
 ```

--- a/docs/plugin-middleware.md
+++ b/docs/plugin-middleware.md
@@ -7,8 +7,6 @@ title: "Middleware Plugin"
 
 Middleware plugins have the capability to modify the API (web and cli) layer, either adding new endpoints or intercepting requests.
 
-<div id="codefund">''</div>
-
 ### API
 
 ```typescript

--- a/docs/plugin-storage.md
+++ b/docs/plugin-storage.md
@@ -7,8 +7,6 @@ title: "Storage Plugin"
 
 Verdaccio by default uses a file system storage plugin [local-storage](https://github.com/verdaccio/local-storage). The default storge can be easily replaced, either using a community plugin or creating one by your own.
 
-<div id="codefund">''</div>
-
 ### API
 
 Storage plugins are composed of two objects, the `IPluginStorage<T>` and the `IPackageStorage`.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -15,8 +15,6 @@ There are 5 types of plugins:
 
 > If you are interested to develop your own plugin, read the [development](dev-plugins.md) section.
 
-<div id="codefund">''</div>
-
 ## Usage
 
 ### Installation

--- a/docs/protect-your-dependencies.md
+++ b/docs/protect-your-dependencies.md
@@ -5,8 +5,6 @@ title: "Protecting packages"
 
 `verdaccio` allows you protect publish, to achieve that you will need to set up correctly your [packages access](packages).
 
-<div id="codefund">''</div>
-
 ### Package configuration
 
 Let's see for instance the following set up. You have a set of dependencies what are prefixed with `my-company-*` and you need to protect them from anonymous or another logged user without right credentials.

--- a/docs/puppet.md
+++ b/docs/puppet.md
@@ -12,8 +12,6 @@ There are two variants to install verdaccio using this Puppet module:
 * Apply-mode (with puppet-apply and no puppetmaster setup needed)
 * Master-Agent-mode (with puppet-agent accessing your configuration through the puppetmaster).
 
-<div id="codefund">''</div>
-
 In both variants you have to explicitely call "class nodejs {}" in your puppet script because
 the puppet-verdaccio module only defines this as a requirement, so you have all the flexibility you want when installing nodejs.
 Scroll down for details about Master-Agent-mode variant.

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -6,8 +6,6 @@ title: "Reverse Proxy Setup"
 Using a reverse proxy is a common practice. The following configurations are the
 most recommended and used ones.
 
-<div id="codefund">''</div>
-
 # Apache
 
 Apache and `mod_proxy` should **not decode/encode slashes** and leave them as they are:

--- a/docs/security-policy.md
+++ b/docs/security-policy.md
@@ -4,5 +4,3 @@ title: "Security Policy"
 ---
 
 Follow our security policy on [GitHub](https://github.com/verdaccio/verdaccio/security/policy)
-
-<div id="codefund">''</div>

--- a/docs/server.md
+++ b/docs/server.md
@@ -5,8 +5,6 @@ title: "Server Configuration"
 
 This is mostly basic linux server configuration stuff but I felt it important to document and share the steps I took to get verdaccio running permanently on my server. You will need root (or sudo) permissions for the following.
 
-<div id="codefund">''</div>
-
 ## Running as a separate user
 First create the verdaccio user:
 

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -5,7 +5,6 @@ title: "Set up the SSL Certificates"
 
 Follow these instructions to configure an SSL certificate to serve an NPM registry over HTTPS.
 
-<div id="codefund">''</div>
 
 * Update the listen property in your `~/.config/verdaccio/config.yaml`:
 

--- a/docs/talks.md
+++ b/docs/talks.md
@@ -16,7 +16,6 @@ We list the talks about Verdaccio, if you gave a talk or you are about to give o
 ## Cover your Projects with a Multi purpose Lightweight Node.js Registry June 2020
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/oVCjDWeehAQ?enablejsapi=1" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<div id="codefund">''</div>
 
 > The last shared talk is always highlighted here. We help you share your voice with the community.
 

--- a/docs/uplinks.md
+++ b/docs/uplinks.md
@@ -7,8 +7,6 @@ An *uplink* is a link with an external registry that provides access to external
 
 ![Uplinks](https://user-images.githubusercontent.com/558752/52976233-fb0e3980-33c8-11e9-8eea-5415e6018144.png)
 
-<div id="codefund">''</div>
-
 ### Usage
 
 ```yaml

--- a/docs/web.md
+++ b/docs/web.md
@@ -5,8 +5,6 @@ title: "Web User Interface"
 
 ![Uplinks](https://user-images.githubusercontent.com/558752/52916111-fa4ba980-32db-11e9-8a64-f4e06eb920b3.png)
 
-<div id="codefund">''</div>
-
 Verdaccio has a web user interface to display only the private packages and can be customisable.
 
 ```yaml

--- a/docs/what-is-verdaccio.md
+++ b/docs/what-is-verdaccio.md
@@ -5,8 +5,6 @@ title: "What is Verdaccio?"
 
 Verdaccio is a **lightweight private npm proxy registry** built in **Node.js**
 
-<div id="codefund">''</div>
-
 <iframe width="560" height="315" src="https://www.youtube.com/embed/hDIFKzmoCaA?enablejsapi=1" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## What's a registry
@@ -56,7 +54,6 @@ It explains all the benefits and good practices about how to run a registry that
 could be used for hosting a registry, emulate real testing environments or improve your developer workflow. 
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/oVCjDWeehAQ?enablejsapi=1" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<div id="codefund">''</div>
 
 * It's a web app based on Node.js
 * It's a private npm registry

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -13,8 +13,6 @@ Loosely based upon the instructions found [here](http://asysadmin.tumblr.com/pos
 3. Create your `config.yaml` file in this location `(c:\verdaccio\config.yaml)`
 4. Windows Service Setup
 
-<div id="codefund">''</div>
-
 ## Using NSSM
 
 ALTERNATIVE METHOD: (WinSW package was missing when I tried to download it)


### PR DESCRIPTION
Removing unnecessary block of code `<div id="codefund">''</div>` from markdown files inside docs/ folder.

Solving issue #271 