### PR TITLE
fix default language

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -35,7 +35,7 @@ i18n:
 ```
 
 > ⚠️ Only the languages in this [list](https://github.com/verdaccio/ui/tree/master/i18n/translations) are available, feel free to contribute with more. The default
-> one is es-US
+> one is en-US
 
 ### Configuration
 


### PR DESCRIPTION
default language is listed as "es-US", should probably be "en-US" as "es-US" isn't listed anyway