### PR TITLE
Typo on `docs/best-practices.md`

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -67,7 +67,7 @@ There's two options here:
 
    ```bash
     npm version 0.1.3-my-temp-fix
-    npm --publish --tag fix --registry http://localhost:4873
+    npm publish --tag fix --registry http://localhost:4873
    ```
 
    This way your package will be used until its original maintainer updates his public package to `0.1.3`.


### PR DESCRIPTION
Typo on command:

```
npm publish --tag fix --registry http://localhost:4873
```