### PR TITLE
docker doc fix

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -64,7 +64,7 @@ V_PATH=/path/for/verdaccio; docker run -it --rm --name verdaccio \
 > if you are running in a server, you might want to add -d to run it in the background
 
 >Note: Verdaccio runs as a non-root user (uid=10001) inside the container, if you use bind mount to override default, 
-you need to make sure the mount directory is assigned to the right user. In above example, you need to run `sudo chown -R 10001:65533 /opt/verdaccio` otherwise 
+you need to make sure the mount directory is assigned to the right user. In above example, you need to run `sudo chown -R 10001:65533 /path/for/verdaccio` otherwise 
 you will get permission errors at runtime. 
 [Use docker volume](https://docs.docker.com/storage/volumes/) is recommended over using bind mount.
 


### PR DESCRIPTION
fixes #218 

Currently the Docker instructions mention `sudo chown -R 10001:65533 /opt/verdaccio` but this would have to be done in the container while it is running.

It should be `sudo chown -R 10001:65533 /path/for/verdaccio` in this case.

https://verdaccio.org/docs/en/docker.html