### PR TITLE
doc:correct helm commands

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -37,13 +37,13 @@ helm repo add verdaccio https://charts.verdaccio.org
 In this example we use `npm` as release name:
 
 ```bash
-helm install --name npm verdaccio/verdaccio
+helm install npm verdaccio/verdaccio
 ```
 
 ### Deploy a specific version
 
 ```bash
-helm install --name npm --set image.tag=3.13.1 verdaccio/verdaccio
+helm install npm --set image.tag=3.13.1 verdaccio/verdaccio
 ```
 
 ### Upgrading Verdaccio
@@ -55,7 +55,7 @@ helm upgrade npm verdaccio/verdaccio
 ### Uninstalling
 
 ```bash
-helm del --purge npm
+helm uninstall npm
 ```
 
 **Note:** this command delete all the resources, including packages that you may
@@ -99,7 +99,7 @@ Now you can deploy the Verdaccio Helm chart and specify which configuration to
 use:
 
 ```bash
-helm install --name npm --set customConfigMap=verdaccio-config verdaccio/verdaccio
+helm install npm --set customConfigMap=verdaccio-config verdaccio/verdaccio
 ```
 
 #### NGINX proxy body-size limit


### PR DESCRIPTION
The following helm commands are not valid with `helm 3`.

The changes were tested on:
`version.BuildInfo{Version:"v3.2.1", GitCommit:"fe51cd1e31e6a202cba7dead9552a6d418ded79a", GitTreeState:"clean", GoVersion:"go1.13.10"}
`