### PR TITLE
Documentation grammar, clarity and spelling fixes

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -5,7 +5,7 @@ title: "Authentication"
 
 The authentication is tied to the auth [plugin](plugins.md) you are using. The package restrictions are also handled by the [Package Access](packages.md).
 
-The client authentication is handled by `npm` client itself. Once you login to the application:
+The client authentication is handled by the `npm` client itself. Once you log in to the application:
 
 ```bash
 npm adduser --registry http://localhost:4873
@@ -22,7 +22,7 @@ registry=http://localhost:5555/
 
 #### Anonymous publish
 
-`verdaccio` allows you to enable anonymous publish, to achieve that you will need to set up correctly your [packages access](packages.md).
+`verdaccio` allows you to enable anonymous publish. To achieve that you will need to correctly set up your [packages access](packages.md).
 
 Eg:
 
@@ -39,21 +39,21 @@ As is described [on issue #212](https://github.com/verdaccio/verdaccio/issues/21
 
 ### The meaning of `$all` and `$anonymous`
 
-As you know *Verdaccio* uses the `htpasswd` by default. That plugin does not implement the methods `allow_access`, `allow_publish` and `allow_unpublish`.
+As you know *Verdaccio* uses `htpasswd` by default. That plugin does not implement the methods `allow_access`, `allow_publish` and `allow_unpublish`.
 Thus, *Verdaccio* will handle that in the following way:
 
 * If you are not logged in (you are anonymous), `$all` and `$anonymous` means exactly the same.
-* If you are logged in, `$anonymous` won't be part of your groups and `$all` will match any logged user. A new group `$authenticated` will be added to the list.
+* If you are logged in, `$anonymous` won't be part of your groups and `$all` will match any logged user. A new group `$authenticated` will be added to your group list.
 
-As a takeaway, `$all` **will match all users, independently whether is logged or not**.
+Please note: `$all` **will match all users, whether logged in or not**.
 
 **The previous behavior only applies to the default authentication plugin**. If you are using a custom plugin and such plugin implements
 `allow_access`, `allow_publish` or `allow_unpublish`, the resolution of the access depends on the plugin itself. Verdaccio will only set the default groups.
 
 Let's recap:
 
-* **logged**: `$all`, `$authenticated`, + groups added by the plugin
-* **anonymous (logged out)**: `$all` and `$anonymous`.
+* **logged in**: `$all` and `$authenticated` + groups added by the plugin.
+* **logged out (anonymous)**: `$all` and `$anonymous`.
 
 ## Default htpasswd
 
@@ -74,4 +74,4 @@ Property | Type | Required | Example | Support | Description
 file | string | Yes | ./htpasswd | all | file that host the encrypted credentials
 max_users | number | No | 1000 | all | set limit of users
 
-In case you decide to not allow users to sign up, you can set `max_users: -1`.
+In case you decide to prevent users from signing up themselves, you can set `max_users: -1`.

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -34,11 +34,11 @@ Always remember, **the order of packages access is important**, packages are mat
 
 ### Using public packages from npmjs.org
 
-If some package doesn't exist in the storage, server will try to fetch it from npmjs.org. If npmjs.org is down, it serves packages from cache pretending that no other packages exist. **Verdaccio will download only what's needed (requested by clients)**, and this information will be cached, so if client will ask the same thing second time, it can be served without asking npmjs.org for it.
+If a package doesn't exist in the storage, the server will try to fetch it from npmjs.org. If npmjs.org is down, it serves packages from the cache pretending that no other packages exist. **Verdaccio will download only what's needed (requested by clients)**, and this information will be cached, so if the client requests the same thing a second time it can be served without asking npmjs.org for it.
 
 **Example:**
 
-If you successfully request `express@4.0.1` from this server once, you'll be able to do it again (with all it's dependencies) any time, even if npmjs.org is down. Though note that `express@4.0.0` will not be downloaded until it's actually needed by somebody. And if npmjs.org is offline, the server will say that only `express@4.0.1` (what's in the cache) is published, but nothing else.
+If you successfully request `express@4.0.1` from the server once, you'll be able to do it again (with all of it's dependencies) any time, even if npmjs.org is down. Though note that `express@4.0.0` will not be downloaded until it's actually needed by somebody. And if npmjs.org is offline, the server will say that only `express@4.0.1` (what's in the cache) is published, but nothing else.
 
 ### Override public packages
 
@@ -102,7 +102,7 @@ That way, **nobody can access your registry unless they are authorized, and priv
 
 ### Secured Connections
 
-Using **HTTPS** is a common recomendation, for such reason we recommend reading the [SSL](ssl.md) section to make Verdaccio secure, or alternatively using an HTTPS [reverse proxy](reverse-proxy.md) on top of Verdaccio.
+Using **HTTPS** is a common recommendation. For this reason we recommend reading the [SSL](ssl.md) section to make Verdaccio secure, or alternatively using an HTTPS [reverse proxy](reverse-proxy.md) on top of Verdaccio.
 
 ### Expiring Tokens
 

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -38,7 +38,7 @@ If some package doesn't exist in the storage, server will try to fetch it from n
 
 **Example:**
 
-If you successfully request `express@4.0.1` from this server once, you'll be able to do it again (with all it's dependencies) anytime even if npmjs.org is down. But say `express@4.0.0` will not be downloaded until it's actually needed by somebody. And if npmjs.org is offline, this server would say that only `express@4.0.1` (only what's in the cache) is published, but nothing else.
+If you successfully request `express@4.0.1` from this server once, you'll be able to do it again (with all it's dependencies) any time, even if npmjs.org is down. Though note that `express@4.0.0` will not be downloaded until it's actually needed by somebody. And if npmjs.org is offline, the server will say that only `express@4.0.1` (what's in the cache) is published, but nothing else.
 
 ### Override public packages
 
@@ -48,7 +48,7 @@ There's two options here:
 
 1. You want to create a separate **fork** and stop synchronizing with public version.
 
-   If you want to do that, you should modify your configuration file so verdaccio won't make requests regarding this package to npmjs anymore. Add a separate entry for this package to `config.yaml` and remove `npmjs` from `proxy` list and restart the server.
+   If you want to do that, you should modify your configuration file so Verdaccio won't make requests regarding this package to npmjs anymore. Add a separate entry for this package to `config.yaml` and remove `npmjs` from `proxy` list and restart the server.
 
    ```yaml
     packages:
@@ -59,9 +59,9 @@ There's two options here:
         # proxy:
    ```
 
-   When you publish your package locally, **you should probably start with version string higher than existing one**, so it won't conflict with existing package in the cache.
+   When you publish your package locally, **you should probably start with a version string higher than the existing package** so it won't conflict with that package in the cache.
 
-2. You want to temporarily use your version, but return to public one as soon as it's updated.
+2. You want to temporarily use your version, but return to the public one as soon as it's updated.
 
    In order to avoid version conflicts, **you should use a custom pre-release suffix of the next patch version**. For example, if a public package has version 0.1.2, you can upload `0.1.3-my-temp-fix`.
 
@@ -77,11 +77,11 @@ There's two options here:
 
 ## Security
 
-The security starts in your environment, for such thing we totally recommend read **[10 npm Security Best Practices](https://snyk.io/blog/ten-npm-security-best-practices/)** and follow the recommendation.
+Security starts in your environment. For such things we recommend reading **[10 npm Security Best Practices](https://snyk.io/blog/ten-npm-security-best-practices/)** and following the steps outlined there.
 
 ### Package Access
 
-By default all packages are you publish in Verdaccio are accessible for all public, we totally recommend protect your registry from external non authorized users updating `access` property to `$authenticated`.
+By default all packages you publish in Verdaccio are accessible for all users. We recommend protecting your registry from external non-authorized users by updating the `access` property of your packages to `$authenticated`.
 
 ```yaml
   packages:
@@ -96,13 +96,13 @@ By default all packages are you publish in Verdaccio are accessible for all publ
       publish: $authenticated
    ```
 
-That way, **nobody will take advantage of your registry unless it's authorized and private packages won't be displayed in the User Interface**.
+That way, **nobody can access your registry unless they are authorized, and private packages won't be displayed in the web interface**.
 
 ## Server
 
 ### Secured Connections
 
-Using **HTTPS** is a common recomendation, for such reason we recommend read the [SSL](ssl.md) section to make Verdaccio secure or using a HTTPS [reverse proxy](reverse-proxy.md) on top of Verdaccio.
+Using **HTTPS** is a common recomendation, for such reason we recommend reading the [SSL](ssl.md) section to make Verdaccio secure, or alternatively using an HTTPS [reverse proxy](reverse-proxy.md) on top of Verdaccio.
 
 ### Expiring Tokens
 
@@ -122,6 +122,6 @@ security:
 
 **Using this configuration will override the current system and you will be able to control how long the token will live**.
 
-Using JWT also improves the performance with authentication plugins, the old system will perform an unpackage and validating the credentials in each request, while JWT will rely on the token signature avoiding the overhead for the plugin.
+Using JWT also improves the performance with authentication plugins. The old system will perform an unpackage and validate the credentials on every request, while JWT will rely on the token signature instead, avoiding the overhead for the plugin.
 
 As a side note, at **npmjs the token never expires**.

--- a/docs/cli-registry.md
+++ b/docs/cli-registry.md
@@ -3,7 +3,7 @@ id: cli-registry
 title: "Using a private registry"
 ---
 
-Setting up a private registry can be achieved in few ways, let's review all of them, this formula might be different based on the package manager you are using.
+Setting up a private registry can be achieved in a few ways, let's review all of them. The following commands might be different based on the package manager you are using.
 
 ### npm (5.x, 6.x)
 
@@ -44,7 +44,7 @@ If you are using either `npm@5.4.x` or `npm@5.5.x`, there are [known issues with
 
 #### SSL and certificates
 
-When using verdaccio under SSL without a valid certificate, define `strict-ssl` in your config file is required otherwise you will get `SSL Error: SELF_SIGNED_CERT_IN_CHAIN` errors.
+When using Verdaccio under SSL without a valid certificate, defining `strict-ssl` in your config file is required otherwise you will get `SSL Error: SELF_SIGNED_CERT_IN_CHAIN` errors.
 
 `npm` does not support [invalid certificates anymore](https://blog.npmjs.org/post/78085451721/npms-self-signed-certificate-is-no-more) since 2014.
 
@@ -55,7 +55,7 @@ npm config set strict-ssl false
 
 ### npm (7.x)
 
-The `v7.0.0` is more strict with the new `v2` lock file, if you have mixed `resolved` fields in your lock file, for instance, having this in your lockfile:
+npm `v7.0.0` is more strict with the new `v2` lockfile. If you have mixed `resolved` fields in your lockfile, for instance, having this in your lockfile:
 
 ```json
 {
@@ -97,9 +97,9 @@ Either running `npm i --registry https://registry.npmjs.org` or using `.npmrc` w
 
 > Be aware npm configurations are valid on the classic version
 
-The classic version is able to regonize the `.npmrc` file, but, also provides their own configuration file named `.yarnrc`.
+The classic version is able to regonize the `.npmrc` file, but also provides their own configuration file named `.yarnrc`.
 
-To setup a registry create a file and define a registry.
+To set up a registry, create a file and define a registry.
 
 ```
 // .yarnrc

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,7 +3,7 @@ id: cli
 title: "Command Line Tool"
 ---
 
-The Verdaccio CLI is your tool to start the application.
+The Verdaccio CLI is your tool to start and stop the application.
 
 ## Commands
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,7 +3,7 @@ id: cli
 title: "Command Line Tool"
 ---
 
-The verdaccio CLI is your go start the application.
+The Verdaccio CLI is your tool to start the application.
 
 ## Commands
 
@@ -19,15 +19,15 @@ Command | Default | Example | Description
 
 ## Default config file location
 
-To locate the home directory, we rely on **$XDG_DATA_HOME** as a first choice and Windows environment we look for [APPDATA environment variable](https://www.howtogeek.com/318177/what-is-the-appdata-folder-in-windows/).
+To locate the home directory, we rely on **$XDG_DATA_HOME** as a first choice and for Windows environments we look for the [APPDATA environment variable](https://www.howtogeek.com/318177/what-is-the-appdata-folder-in-windows/).
 
 ## Config file format
 
-Config file should be YAML, JSON or NodeJS module. YAML format is detected by parsing config file extension (yaml or yml, case insensitive).
+Config files should be YAML, JSON or a NodeJS module. YAML format is detected by parsing config file extension (yaml or yml, case insensitive).
 
 ## Default storage location
 
-We use **$XDG_DATA_HOME** environment variable as default to locate the storage by default which [should be the same](https://askubuntu.com/questions/538526/is-home-local-share-the-default-value-for-xdg-data-home-in-ubuntu-14-04) as $HOME/.local/share.
+We use the **$XDG_DATA_HOME** environment by variable default to locate the storage by default which [should be the same](https://askubuntu.com/questions/538526/is-home-local-share-the-default-value-for-xdg-data-home-in-ubuntu-14-04) as $HOME/.local/share.
 If you are using a custom storage, this location is irrelevant.
 
 ## Default database file location

--- a/docs/config.md
+++ b/docs/config.md
@@ -3,13 +3,13 @@ id: configuration
 title: "Configuration File"
 ---
 
-This file is the cornerstone of verdaccio where you can modify the default behaviour, enable plugins and extend features.
+This file is the cornerstone of Verdaccio where you can modify the default behaviour, enable plugins and extend features.
 
 A default configuration file `config.yaml` is created the very first time you run `verdaccio`.
 
 ## Default Configuration
 
-The default configuration has support for **scoped** packages and allow any user to access all packages but only **authenticated users to publish**.
+The default configuration has support for **scoped** packages and allows any user to **access** all packages, but only authenticated users to **publish**.
 
 ```yaml
 storage: ./storage
@@ -32,7 +32,7 @@ logs:
 
 ## Sections
 
-The following sections explain what each property means and the different options.
+The following sections explain what each property means and their different options.
 
 ### Storage
 
@@ -44,15 +44,15 @@ storage: ./storage
 
 ### Plugins
 
-Is the location of the plugin directory. Useful for Docker/Kubernetes based deployments.
+Is the location of the plugin directory. Useful for Docker/Kubernetes-based deployments.
 
 ```yaml
 plugins: ./plugins
 ```
 
-### Authentification
+### Authentication
 
-The authentification set up is done here, the default auth is based on `htpasswd` and is built-in. You can modify this behaviour via [plugins](plugins.md). For more information about this section read the [auth page](auth.md).
+The authentication setup is done here. The default auth is based on `htpasswd` and is built in. You can modify this behaviour via [plugins](plugins.md). For more information about this section read the [auth page](auth.md).
 
 ```yaml
 auth:
@@ -65,9 +65,9 @@ auth:
 
 <small>Since: `verdaccio@4.0.0` [#168](https://github.com/verdaccio/verdaccio/pull/168)</small>
 
-The security block allows you to customise the token signature. To enable [JWT (json web token)](https://jwt.io/) new signture you need to add the block `jwt` to `api` section,  `web` uses by default `jwt`.
+The security block allows you to customise the token signature. To enable a new [JWT (JSON Web Tokens)](https://jwt.io/) signature you need to add the block `jwt` to the `api` section; `web` uses `jwt` by default.
 
-The configuration is separated in two sections, `api` and `web`. To use JWT on  `api`, it has to be defined, otherwise will use the legacy token signature (`aes192`). For JWT you might customize the [signature](https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback) and the token [verification](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback) with your own properties.
+The configuration is separated in two sections, `api` and `web`. To use JWT on  `api` it has to be defined, otherwise the legacy token signature (`aes192`) will be used. For JWT you might want to customize the [signature](https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback) and the token [verification](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback) with your own properties.
 
 ```
 security:
@@ -84,6 +84,7 @@ security:
      verify:
      	someProp: [value]
 ```
+
 > We highly recommend move to JWT since legacy signature (`aes192`) is deprecated and will disappear in future versions.
 
 ### Server
@@ -102,7 +103,7 @@ server:
 
 ### Web UI
 
-This property allow you to modify the look and feel of the web UI. For more information about this section read the [web ui page](web.md).
+This property allow you to modify the look and feel of the web UI. For more information about this section read the [web UI page](web.md).
 
 ```yaml
 web:
@@ -114,7 +115,7 @@ web:
 
 ### Uplinks
 
-Uplinks is the ability of the system to fetch packages from remote registries when those packages are not available locally. For more information about this section read the [uplinks page](uplinks.md).
+Uplinks add the ability to fetch packages from remote registries when those packages are not available locally. For more information about this section read the [uplinks page](uplinks.md).
 
 
 ```yaml
@@ -125,7 +126,7 @@ uplinks:
 
 ### Packages
 
-Packages allow the user to control how the packages are gonna be accessed. For more information about this section read the [packages page](packages.md).
+This section allows you to control how packages are accessed. For more information about this section read the [packages page](packages.md).
 
 
 ```yaml
@@ -140,7 +141,7 @@ packages:
 
 ### Offline Publish
 
-By default `verdaccio` does not allow to publish when the client is offline, that behavior can be overridden by setting this to *true*.
+By default `verdaccio` does not allow you to publish packages when the client is offline. This can be can be overridden by setting this value to *true*.
 
 ```yaml
 publish:
@@ -159,7 +160,7 @@ url_prefix: /verdaccio/
 
 ### Max Body Size
 
-By default the maximum body size for a JSON document is `10mb`, if you run in errors as `"request entity too large"` you may increase this value.
+By default the maximum body size for a JSON document is `10mb`, if you run into errors that state `"request entity too large"` you may increase this value.
 
 ```yaml
 max_body_size: 10mb
@@ -167,7 +168,7 @@ max_body_size: 10mb
 
 ### Listen Port
 
-`verdaccio` runs by default in the port `4873`. Changing the port can be done via [cli](cli.md) or in the configuration file, the following options are valid.
+`verdaccio` runs by default on the port `4873`. Changing the port can be done via [CLI](cli.md) or in the configuration file. The following options are valid:
 
 ```yaml
 listen:
@@ -181,8 +182,7 @@ listen:
 
 ### HTTPS
 
-To enable `https` in `verdaccio` it's enough to set the `listen` flag with the protocol *https://*. For more information about this section read the [ssl page](ssl.md).
-
+To enable `https` in `verdaccio` it's enough to set the `listen` flag with the protocol *https://*. For more information about this section read the [SSL page](ssl.md).
 
 ```yaml
 https:
@@ -197,7 +197,7 @@ Proxies are special-purpose HTTP servers designed to transfer data from remote s
 
 #### http_proxy and https_proxy
 
-If you have a proxy in your network you can set a `X-Forwarded-For` header using the following properties.
+If you have a proxy in your network you can set a `X-Forwarded-For` header using the following properties:
 
 ```yaml
 http_proxy: http://something.local/
@@ -206,7 +206,7 @@ https_proxy: https://something.local/
 
 #### no_proxy
 
-This variable should contain a comma-separated list of domain extensions proxy should not be used for.
+This variable should contain a comma-separated list of domain extensions that the proxy should not be used for.
 
 ```yaml
 no_proxy: localhost,127.0.0.1
@@ -214,7 +214,7 @@ no_proxy: localhost,127.0.0.1
 
 ### Notifications
 
-Enabling notifications to third-party tools is fairly easy via web hooks. For more information about this section read the [notifications page](notifications.md).
+Enabling notifications to third-party tools is fairly easy via webhooks. For more information about this section read the [notifications page](notifications.md).
 
 ```yaml
 notify:
@@ -247,11 +247,11 @@ middlewares:
 
 This release includes a new property named `experiments` that can be placed in the `config.yaml` and is completely optional.
 
-We want to be able to ship new things without affecting production environments. This flag allows us to add new features and get feedback from the community that wants to use them.
+We want to be able to ship new things without affecting production environments. This flag allows us to add new features and get feedback from the community who decides to use them.
 
-The features that are under this flag might not be stable or might be removed in future releases.
+The features under this flag might not be stable or might be removed in future releases.
 
-Here one example:
+Here is one example:
 
 ```yaml
 experiments:

--- a/docs/how-to-deploy-on-AWS.md
+++ b/docs/how-to-deploy-on-AWS.md
@@ -3,7 +3,7 @@ id: aws
 title: "Amazon Web Services"
 ---
 
-This document describes simple steps to setup Verdaccio private registry on Amazon Web Services platform using EC2 service. Considering you already created EC2 Amazon Linux instance, if not then please check this tutorial [AWS EC2 Setup](https://www.howtoinmagento.com/2018/04/aws-cli-commands-for-aws-ec2-amazon.html).
+This document describes simple steps to setup Verdaccio private registry on Amazon Web Services platform using EC2 service. This assumes you have already created an EC2 Amazon Linux instance; if not then please check this tutorial on [AWS EC2 Setup](https://www.howtoinmagento.com/2018/04/aws-cli-commands-for-aws-ec2-amazon.html).
 
 ## Setup & Configuration
 

--- a/docs/how-to-deploy-on-AWS.md
+++ b/docs/how-to-deploy-on-AWS.md
@@ -64,7 +64,7 @@ The URL will look like something:
 
  ``` http://your-ec2-public-ip-address:4873 (You can check your EC2 instance public ip from AWS console) ```
 
-To confirm verdaccio running status, run the command below
+To confirm Verdaccio's running status, run the command below:
 
  ```  pm2 list ```
 

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -3,7 +3,7 @@ id: logger
 title: "Logger"
 ---
 
-As any web application, verdaccio has a customisable built-in logger. You can define multiple types of outputs.
+As with any web application, Verdaccio has a customisable built-in logger. You can define multiple types of outputs.
 
 ```yaml
 logs:

--- a/docs/node-api.md
+++ b/docs/node-api.md
@@ -3,7 +3,7 @@ id: node-api
 title: "Node API"
 ---
 
-Verdaccio can be invoked programmatically. The node API was introduced after version `verdaccio@3.0.0`.
+Verdaccio can be invoked programmatically. The Node API was introduced after version `verdaccio@3.0.0`.
 
 ## Usage
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -5,7 +5,7 @@ title: "Notifications"
 
 Notify was built primarily to use with Slack's Incoming
 webhooks, but will also deliver a simple payload to
-any endpoint. Currently only active for `npm publish`
+any endpoint. This is currently only active for the `npm publish`
 command.
 
 ## Usage
@@ -124,7 +124,7 @@ Package metadata that the template has access
 
 ### Publisher
 
-You can access to the package publisher information in the `content` of a webhook using the `publisher` object.
+You can get access to the package publisher information in the `content` of a webhook using the `publisher` object.
 
 See below the `publisher` object type:
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -3,7 +3,7 @@ id: packages
 title: "Package Access"
 ---
 
-It's a series of contraints that allow or restrict access to the local storage based in specific criteria.
+This is a series of constraints that allow or restrict access to the local storage based on specific criteria.
 
 The security constraints remain on the shoulders of the plugin being used, by default `verdaccio` uses the [htpasswd plugin](https://github.com/verdaccio/verdaccio-htpasswd). If you use a different plugin the behaviour might be different. The default plugin does not handle `allow_access` and `allow_publish` by itself, it uses an internal fallback in case the plugin is not ready for it.
 

--- a/docs/plugin-auth.md
+++ b/docs/plugin-auth.md
@@ -34,7 +34,7 @@ auth:
 
 > If one of the plugin in the chain is able to resolve the request, the next ones will be ignored.
 
-## How to the authentication plugin works?
+## How do the authentication plugin works?
 
 Basically we have to return an object with a single method called `authenticate` that will recieve 3 arguments (`user, password, callback`).
 
@@ -127,7 +127,7 @@ callback(err);
 
 ### `changePassword` callback
 
-##### If the request success
+##### If the request is successful
 
 If the service is able to create an user, return `true` as the second argument.
 

--- a/docs/protect-your-dependencies.md
+++ b/docs/protect-your-dependencies.md
@@ -3,11 +3,11 @@ id: protect-your-dependencies
 title: "Protecting packages"
 ---
 
-`verdaccio` allows you protect publish, to achieve that you will need to set up correctly your [packages access](packages).
+`verdaccio` allows you protect publishing to your registry. To achieve that you will need to set up correctly configure your [packages access](packages).
 
 ### Package configuration
 
-Let's see for instance the following set up. You have a set of dependencies what are prefixed with `my-company-*` and you need to protect them from anonymous or another logged user without right credentials.
+Let's see for instance the following set up. You have a set of dependencies that are prefixed with `my-company-*` and you need to protect them from anonymous or other non-authorized logged-in users.
 
 ```yaml
   'my-company-*':
@@ -16,24 +16,26 @@ Let's see for instance the following set up. You have a set of dependencies what
     proxy: npmjs
 ```
 
-With this configuration, basically we allow to groups **admin** and **teamA** to *publish* and **teamA**   **teamB** **teamC** *access* to such dependencies.
+With this configuration, we allow the groups **admin** and **teamA** to *publish* and **teamA**,  **teamB** and **teamC** to *access* the specified dependencies.
 
-### Use case: teamD try to access the dependency
+### Use case: teamD tries to access the dependency
 
-So, if I am logged as **teamD**. I shouldn't be able to access all dependencies that match with `my-company-*` pattern.
+So, if I am logged as **teamD**. I shouldn't be able to access all dependencies that match the `my-company-*` pattern.
 
 ```bash
 ➜ npm whoami
 teamD
 ```
-I won't have access to such dependencies and also won't be visible via web for user **teamD**. If I try to access the following will happen.
+
+I won't have access to such dependencies and they also won't be visible via the web interface for user **teamD**. If I try to access it, the following will happen:
 
 ```bash
 ➜ npm install my-company-core
 npm ERR! code E403
 npm ERR! 403 Forbidden: webpack-1@latest
 ```
-or with `yarn`
+
+or with `yarn`:
 
 ```bash
 ➜ yarn add my-company-core

--- a/docs/protect-your-dependencies.md
+++ b/docs/protect-your-dependencies.md
@@ -3,7 +3,7 @@ id: protect-your-dependencies
 title: "Protecting packages"
 ---
 
-`verdaccio` allows you protect publishing to your registry. To achieve that you will need to set up correctly configure your [packages access](packages).
+Verdaccio allows you protect publishing to your registry. To achieve that you will need to set up correctly configure your [packages access](packages).
 
 ### Package configuration
 

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -163,9 +163,9 @@ you would need something like this in your `config.yaml`.
 url_prefix: /sub_directory/
 ```
 
-If you run verdaccio behind reverse proxy, you may noticed all resource file served as relative path, like `http://127.0.0.1:4873/-/static`
+If you run Verdaccio behind reverse proxy, you may noticed all resource file served as relative path, like `http://127.0.0.1:4873/-/static`
 
-To resolve this issue, **you should send real domain and port to verdaccio with `Host` header**
+To resolve this issue, **you should send real domain and port to Verdaccio with `Host` header**
 
 Nginx configure should look like this:
 
@@ -177,9 +177,10 @@ location / {
     proxy_set_header X-Forwarded-Proto $scheme;
 }
 ```
-For this case, `url_prefix` should **NOT** set in verdaccio config
+For this case, `url_prefix` should **NOT** set in Verdaccio config
 
 ---
+
 or a sub-directory installation:
 
 ```nginx
@@ -192,4 +193,4 @@ location ~ ^/verdaccio/(.*)$ {
 ```
 For this case, `url_prefix` should set to `/verdaccio/`
 
-> Note: There is a Slash after install path (`https://your-domain:port/verdaccio/`)!
+> Note: There is a slash after the install path (`https://your-domain:port/verdaccio/`)!

--- a/docs/server.md
+++ b/docs/server.md
@@ -3,10 +3,11 @@ id: server-configuration
 title: "Server Configuration"
 ---
 
-This is mostly basic linux server configuration stuff but I felt it important to document and share the steps I took to get verdaccio running permanently on my server. You will need root (or sudo) permissions for the following.
+This is mostly basic Linux server configuration stuff but I felt it important to document and share the steps I took to get Verdaccio running permanently on my server. You will need root (or sudo) permissions for the following steps.
 
 ## Running as a separate user
-First create the verdaccio user:
+
+First create a verdaccio user:
 
 ```bash
 $ sudo adduser --system --gecos 'Verdaccio NPM mirror' --group --home /var/lib/verdaccio verdaccio
@@ -28,6 +29,7 @@ $ cd
 The `cd` command sends you to the home directory of the verdaccio user. Make sure you run verdaccio at least once to generate the config file. Edit it according to your needs.
 
 ## Listening on all addresses
+
 If you want to listen to every external address set the listen directive in the config to:
 ```yaml
 # you can specify listen address (or simply a port)
@@ -38,15 +40,17 @@ If you are running verdaccio in a Amazon EC2 Instance, [you will need set the li
 
 > Configure Apache or nginx? Please check out the [Reverse Proxy Setup](reverse-proxy.md)
 
-## Keeping verdaccio running forever
-You can use node package called ['forever'](https://github.com/nodejitsu/forever) to keep verdaccio running all the time.
+## Keeping Verdaccio running forever
+
+You can use a Node package called ['forever'](https://github.com/nodejitsu/forever) to keep Verdaccio running all the time.
 
 First install `forever` globally:
+
 ```bash
 $ sudo npm install -g forever
 ```
 
-Make sure you've run verdaccio at least once to generate the config file and write down the created admin user. You can then use the following command to start verdaccio:
+Make sure you've run Verdaccio at least once to generate the config file and write down the created admin user. You can then use the following command to start Verdaccio:
 
 ```bash
 $ forever start `which verdaccio`
@@ -55,8 +59,10 @@ $ forever start `which verdaccio`
 You can check the documentation for more information on how to use forever.
 
 ## Surviving server restarts
-You can use `crontab` and `forever` together to start verdaccio after a server reboot.
-When you're logged in as the verdaccio user do the following:
+
+You can use `crontab` and `forever` together to start Verdaccio after a server reboot.
+
+When you're logged in as the Verdaccio user do the following:
 
 ```bash
 $ crontab -e
@@ -77,6 +83,7 @@ $ which verdaccio
 ```
 
 ## Using systemd
+
 Instead of `forever` you can use `systemd` for starting verdaccio and keeping it running. Verdaccio installation has systemd unit, you only need to copy it:
 ```bash
 $ sudo cp /usr/lib/node_modules/verdaccio/systemd/verdaccio.service /lib/systemd/system/ && sudo systemctl daemon-reload

--- a/docs/server.md
+++ b/docs/server.md
@@ -7,7 +7,7 @@ This is mostly basic Linux server configuration stuff but I felt it important to
 
 ## Running as a separate user
 
-First create a verdaccio user:
+First create a Verdaccio user:
 
 ```bash
 $ sudo adduser --system --gecos 'Verdaccio NPM mirror' --group --home /var/lib/verdaccio verdaccio
@@ -19,14 +19,14 @@ Or, in case you do not have `adduser`:
 $ sudo useradd --system --comment 'Verdaccio NPM mirror' --create-home --home-dir /var/lib/verdaccio --shell /sbin/nologin verdaccio
 ```
 
-You create a shell as the verdaccio user using the following command:
+You create a shell as the Verdaccio user using the following command:
 
 ```bash
 $ sudo su -s /bin/bash verdaccio
 $ cd
 ```
 
-The `cd` command sends you to the home directory of the verdaccio user. Make sure you run verdaccio at least once to generate the config file. Edit it according to your needs.
+The `cd` command sends you to the home directory of the Verdaccio user. Make sure you run Verdaccio at least once to generate the config file. Edit it according to your needs.
 
 ## Listening on all addresses
 
@@ -36,7 +36,7 @@ If you want to listen to every external address set the listen directive in the 
 listen: 0.0.0.0:4873
 ```
 
-If you are running verdaccio in a Amazon EC2 Instance, [you will need set the listen in change your config file](https://github.com/verdaccio/verdaccio/issues/314#issuecomment-327852203) as is described above.
+If you are running Verdaccio in a Amazon EC2 Instance, [you will need set the listen in change your config file](https://github.com/verdaccio/verdaccio/issues/314#issuecomment-327852203) as is described above.
 
 > Configure Apache or nginx? Please check out the [Reverse Proxy Setup](reverse-proxy.md)
 
@@ -84,7 +84,7 @@ $ which verdaccio
 
 ## Using systemd
 
-Instead of `forever` you can use `systemd` for starting verdaccio and keeping it running. Verdaccio installation has systemd unit, you only need to copy it:
+Instead of `forever` you can use `systemd` for starting Verdaccio and keeping it running. Verdaccio installation has systemd unit, you only need to copy it:
 ```bash
 $ sudo cp /usr/lib/node_modules/verdaccio/systemd/verdaccio.service /lib/systemd/system/ && sudo systemctl daemon-reload
 ```

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -3,7 +3,7 @@ id: ssl
 title: "Set up the SSL Certificates"
 ---
 
-Follow these instructions to configure an SSL certificate to serve an NPM registry over HTTPS.
+Follow these instructions to configure an SSL certificate to serve an npm registry over HTTPS.
 
 
 * Update the listen property in your `~/.config/verdaccio/config.yaml`:

--- a/docs/web.md
+++ b/docs/web.md
@@ -5,7 +5,7 @@ title: "Web User Interface"
 
 ![Uplinks](https://user-images.githubusercontent.com/558752/52916111-fa4ba980-32db-11e9-8a64-f4e06eb920b3.png)
 
-Verdaccio has a web user interface to display only the private packages and can be customisable.
+Verdaccio has a web user interface to display only the private packages and can be customised to your liking.
 
 ```yaml
 web:
@@ -27,7 +27,7 @@ The `primary_color` **must be a valid hex representation**.
 
 ### Internationalization
 
-*Since v4.5.0*, there are translations available
+*Since v4.5.0*, there are translations available.
 
 ```yaml
 i18n:
@@ -50,7 +50,6 @@ primary_color | string | No | "#4b5e40" | `>4` | The primary color to use throug
 scope | string | No | @myscope | `>v3.x` | If you're using this registry for a specific module scope, specify that scope to set it in the webui instructions header
 darkMode | boolean | No | false | `>=v4.6.0` | This mode is an special theme for those want to live in the dark side
 
+> The recommended logo size is `40x40` pixels.
 
-> It is recommended the logo size has the following size `40x40` pixels.
-
-> The `darkMode` can be enabled via UI and is persisted in the local storage, furthermore, also void `primary_color` and dark cannot be customized.
+> The `darkMode` can be enabled via UI and is persisted in the browser local storage. Furthermore, also void `primary_color` and dark cannot be customized.


### PR DESCRIPTION
Hi all,

I'm not sure if purely grammar and spelling fixes are frowned upon here, but I wanted to amend and fix up some of the wording to make the documentation clearer and flow better.

The following pages have received changes:

* Command Line Tool
* Using a private registry
* Configuration File
* Packages
* Authentication
* Notifications
* Best Practices
* Protecting packages
* Amazon Web Services
* Reverse Proxy Setup
* Set up the SSL Certificates
* Authentication Plugin
* Node API

Most of the changes are simple grammar or spelling fixes, but I have reworded whole sentences in certain places to be more readable. I have not changed the meaning behind any of the wording, just how they're written.

Thanks for the awesome tool!