### PR TITLE
Just a simple warning for nginx resolved

### DIFF
--- a/website/translated_docs/de/reverse-proxy.md
+++ b/website/translated_docs/de/reverse-proxy.md
@@ -120,7 +120,6 @@ The following snippet is a full `docker` example can be tested in our [Docker ex
         ssl_certificate     /etc/nginx/cert.crt;
         ssl_certificate_key /etc/nginx/cert.key;
     
-        ssl on;
         ssl_session_cache  builtin:1000  shared:SSL:10m;
         ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;


### PR DESCRIPTION
After run `nginx -t` with ssl configuration, this `warning` appears.
`nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in`
So I removed the line that contains `ssl on;` to fix this warning