### PR TITLE
Add note about npm not sending authentication data with GET requests

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -77,7 +77,7 @@ npm ERR!     /Users/user/.npm/_logs/2017-07-02T12_20_14_834Z-debug.log
 
 You can change the existing behaviour using a different plugin authentication. `verdaccio` just checks whether the user that tried to access or publish a specific package belongs to the right group.
 
-Please note that if you set the `access` permission of a package as something that requires Verdaccio to check your identity, for example `$authenticated`, npm does not send your access key by default when fetching packages. This means all requests for downloading packages will be rejected as they are made anonymously even if you have logged in. To make npm include you access key with all requests, you should set the [always-auth](https://docs.npmjs.com/cli/v7/using-npm/config#always-auth) npm setting to true on any client machines. This can be accomplished by running:
+Please note that if you set the `access` permission of a package to something that requires Verdaccio to check your identity, for example `$authenticated`, npm does not send your access key by default when fetching packages. This means all requests for downloading packages will be rejected as they are made anonymously even if you have logged in. To make npm include you access key with all requests, you should set the [always-auth](https://docs.npmjs.com/cli/v7/using-npm/config#always-auth) npm setting to true on any client machines. This can be accomplished by running:
 
 ```bash
 $ npm config set always-auth=true

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -77,6 +77,12 @@ npm ERR!     /Users/user/.npm/_logs/2017-07-02T12_20_14_834Z-debug.log
 
 You can change the existing behaviour using a different plugin authentication. `verdaccio` just checks whether the user that tried to access or publish a specific package belongs to the right group.
 
+Please note that if you set the `access` permission of a package as something that requires Verdaccio to check your identity, for example `$authenticated`, npm does not send your access key by default when fetching packages. This means all requests for downloading packages will be rejected as they are made anonymously even if you have logged in. To make npm include you access key with all requests, you should set the [always-auth](https://docs.npmjs.com/cli/v7/using-npm/config#always-auth) npm setting to true on any client machines. This can be accomplished by running:
+
+```bash
+$ npm config set always-auth=true
+```
+
 #### Set multiple groups
 
 Defining multiple access groups is fairly easy, just define them with a white space between them.


### PR DESCRIPTION
I made an issue yesterday about npm not working if access permissions of a package require the user to log in (https://github.com/verdaccio/verdaccio/discussions/2152). Apparently this was caused by npm not sending authentication headers with GET requests by default. I thought maybe this should be mentioned in the documentation of Verdaccio as well. Does this addition seem sensible?