### PR TITLE
Fix outdated kubernetes documentation for customConfigMap

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -99,7 +99,7 @@ Now you can deploy the Verdaccio Helm chart and specify which configuration to
 use:
 
 ```bash
-helm install npm --set customConfigMap=verdaccio-config verdaccio/verdaccio
+helm install npm --set existingConfigMap=verdaccio-config verdaccio/verdaccio
 ```
 
 #### NGINX proxy body-size limit


### PR DESCRIPTION
It is now named existingConfigMap

I just ran:

git grep -l 'customConfigMap' | xargs sed -i 's/customConfigMap/existingConfigMap/g'

#361 