### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,9 @@ importers:
       docusaurus-plugin-contributors:
         specifier: workspace:*
         version: link:../packages/tools/docusaurus-plugin-contributors
+      docusaurus-plugin-copy-page-button:
+        specifier: 0.8.2
+        version: 0.8.2(@docusaurus/core@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(debug@4.4.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react@19.2.6)
       docusaurus-plugin-downloads:
         specifier: workspace:*
         version: link:../packages/tools/docusaurus-plugin-downloads
@@ -4310,6 +4313,13 @@ packages:
       '@docusaurus/core': ^2.0.0-alpha.60 || ^2.0.0 || ^3.0.0
       react: ^16.8.4 || ^17 || ^18 || ^19
       react-dom: ^16.8.4 || ^17 || ^18 || ^19
+
+  docusaurus-plugin-copy-page-button@0.8.2:
+    resolution: {integrity: sha512-6flPLd6x5stWlsBmNslh1dTIAUl8U8VwUL5m8rLS23rPtSlemomHP2si/YJvs5dqZc+XlLqR5xOmsRpWznlw0Q==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
+      react: ^18.0.0 || ^19.0.0
 
   docusaurus-plugin-sass@0.2.6:
     resolution: {integrity: sha512-2hKQQDkrufMong9upKoG/kSHJhuwd+FA3iAe/qzS/BmWpbIpe7XKmq5wlz4J5CJaOPu4x+iDJbgAxZqcoQf0kg==}
@@ -14133,6 +14143,11 @@ snapshots:
       to-vfile: 6.1.0
       unified: 9.2.2
       unist-util-is: 4.1.0
+
+  docusaurus-plugin-copy-page-button@0.8.2(@docusaurus/core@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(debug@4.4.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react@19.2.6):
+    dependencies:
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(debug@4.4.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      react: 19.2.6
 
   docusaurus-plugin-sass@0.2.6(@docusaurus/core@3.10.1(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(debug@4.4.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(sass@1.99.0)(webpack@5.103.0):
     dependencies:

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -154,6 +154,7 @@ module.exports = {
   },
 
   plugins: [
+    'docusaurus-plugin-copy-page-button',
     require.resolve('docusaurus-lunr-search'),
     'docusaurus-plugin-sass',
     'docusaurus-plugin-contributors',

--- a/website/package.json
+++ b/website/package.json
@@ -42,6 +42,7 @@
     "copy-text-to-clipboard": "3.2.2",
     "docusaurus-lunr-search": "3.6.0",
     "docusaurus-plugin-contributors": "workspace:*",
+    "docusaurus-plugin-copy-page-button": "0.8.2",
     "docusaurus-plugin-downloads": "workspace:*",
     "dompurify": "3.4.0",
     "lunr": "2.3.9",


### PR DESCRIPTION
This PR
- adds docusaurus-plugin-copy-page-button to package.json
- adds the plugin string to plugins in website/docusaurus.config.js
- puts a "Copy page" button in the docs sidebar — exports current page as clean markdown
- adds one-click "Open in Claude / ChatGPT / Gemini" actions that prefill the markdown

(repo: verdaccio/website, base branch master)

why useful for Verdaccio specifically:
config and deployment are where people get stuck — uplinks, auth/htpasswd, storage, running behind a proxy, docker/kubernetes. the typical flow for someone standing up a private registry is reading a config page → wanting to paste just that page into an LLM to generate a config.yaml for their setup or debug why an uplink/auth rule isn't behaving. this saves the select-and-clean step and keeps the model on your actual config keys.

zero config, auto-injects into the TOC sidebar, theme-aware.

shipping on React Native, Redux Toolkit, Puppeteer, pnpm, PlayCanvas, Arbitrum, Cardano, Sui, Nillion, Flare, Kaia, and ~20 other docs sites. listed on the Docusaurus community plugins page.

happy to close/rebase if not a fit
- repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button
