### PR TITLE
Docs/verdaccio 7 release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,8 +272,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/tools/docusaurus-plugin-downloads
       dompurify:
-        specifier: 3.4.11
-        version: 3.4.11
+        specifier: 3.4.12
+        version: 3.4.12
       lunr:
         specifier: 2.3.9
         version: 2.3.9
@@ -4625,8 +4625,8 @@ packages:
   dompurify@3.4.11:
     resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -13822,7 +13822,7 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
-  dompurify@3.4.9:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -15519,7 +15519,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.13
       dayjs: 1.11.20
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       katex: 0.16.25
       khroma: 2.1.0
       lodash-es: 4.17.21

--- a/website/blog/2026-07-26-verdaccio-7-release.md
+++ b/website/blog/2026-07-26-verdaccio-7-release.md
@@ -1,0 +1,239 @@
+---
+authors: juan_picado
+title: Verdaccio 7 release notes
+description: Verdaccio 7 is a new major line focused on a cleaner runtime, better distribution, package filtering, notifications, and refreshed tooling.
+tags: [release, verdaccio]
+hide_table_of_contents: true
+---
+
+**Verdaccio 7 is the next major line of Verdaccio.** This release keeps the familiar private registry experience, while updating the platform underneath so Verdaccio is easier to run, easier to package, and easier to extend.
+
+For most users, Verdaccio 7 should feel like Verdaccio: a lightweight private npm-compatible registry that works with npm, pnpm, and Yarn. The important changes are in the places that matter over time: **package filtering**, **notifications**, **Web UI polish**, **Docker examples**, **pure ESM plugin support**, **async storage plugins**, **the proxy layer**, and **the way Verdaccio itself is distributed**.
+
+<!--truncate-->
+
+## Try Verdaccio 7
+
+Install Verdaccio 7 from npm:
+
+```bash
+npm install -g verdaccio@7
+```
+
+Or run it with Docker:
+
+```bash
+docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio:7
+```
+
+Use a copy of your storage and configuration when testing a major release.
+
+## Highlights for users
+
+### Package filtering is built in
+
+Verdaccio 7 includes the package filter plugin work, making it possible to **enforce package filtering rules as part of the registry flow**.
+
+This is useful for teams that need to block, quarantine, allow, or replace packages before they reach developers. The filtering is applied where it matters: metadata reads, tarball downloads, uplink syncs, and local package listings.
+
+This work is also available in Verdaccio 6.x through a backport.
+
+### Publish and unpublish notifications
+
+Notifications can now cover **both publish and unpublish events**. Notification templates can include information such as the package being affected and whether the event is a publish or unpublish.
+
+For teams that wire Verdaccio into chat, audit, release, or internal automation systems, this makes registry events easier to track.
+
+This work is also available in Verdaccio 6.x through a backport.
+
+### Web UI improvements
+
+Verdaccio 7 includes several Web UI improvements:
+
+- **Dark mode support**, a refreshed theme foundation, the move from Rematch to React context and SWR, refreshed login/signup/change-password screens, and the new contributors/support content in the info dialog landed in [#5563](https://github.com/verdaccio/verdaccio/pull/5563) by [@juanpicado](https://github.com/juanpicado).
+- Package lists can be sorted by update time through [#5659](https://github.com/verdaccio/verdaccio/pull/5659) by [@mbtools](https://github.com/mbtools).
+- **Web UI search** works better with scoped packages and path-based queries, empty search results are clearer, and package detail tabs behave better across desktop and mobile layouts thanks to [#5647](https://github.com/verdaccio/verdaccio/pull/5647) by [@juanpicado](https://github.com/juanpicado).
+- The Web UI can auto-detect the search response shape, so it no longer depends on the old `searchRemote` flag. That landed in [#5801](https://github.com/verdaccio/verdaccio/pull/5801) by [@juanpicado](https://github.com/juanpicado).
+- The JSON viewer received fixes in [#5651](https://github.com/verdaccio/verdaccio/pull/5651) by [@mbtools](https://github.com/mbtools).
+
+There is also a new `web.assetFolder` option for serving custom assets under `/-/assets/`, which is useful for Docker and volume-based deployments. That landed in [#5653](https://github.com/verdaccio/verdaccio/pull/5653) by [@mbtools](https://github.com/mbtools).
+
+The Web UI is also moving through the shared **`@verdaccio/ui-theme` package**, now used by both Verdaccio 6.x and 7.x. That gives both release lines a common UI foundation. Compatible UI fixes and improvements can continue landing there regularly without waiting for another major Verdaccio release.
+
+### Safer npm search endpoint
+
+The npm `/-/v1/search` endpoint was improved with **rate limiting**, **bounded pagination**, and **batched package access checks**. This avoids scanning the full catalog for every request and makes anonymous search requests less useful as an amplification vector.
+
+The response metadata was also adjusted to be more compatible with npm search clients, including npm 11 on Node.js 24.
+
+This work is also available in Verdaccio 6.x through [#6005](https://github.com/verdaccio/verdaccio/pull/6005).
+
+### Better behavior behind proxies
+
+The Web UI login flow **no longer sends a Basic auth challenge for login failures**. This avoids browser or reverse-proxy behavior where a failed Web UI login can trigger a native browser authentication popup instead of showing the error in the UI.
+
+This fix is also available in Verdaccio 6.x through a backport.
+
+### Updated Docker examples
+
+The Docker examples for Verdaccio 7 were refreshed, including local storage, reverse proxy, plugin examples, and Kubernetes Helm examples.
+
+If you deploy Verdaccio through containers, the examples should be a better starting point for modern setups.
+
+### Pure ESM plugins
+
+Verdaccio 7 can load **pure ESM plugins**. That matters for plugin authors and teams maintaining internal Verdaccio plugins, because new plugins no longer need to publish a CommonJS wrapper just to be loaded by Verdaccio.
+
+CommonJS plugins remain part of the compatibility story, including legacy callback-based storage plugins, but Verdaccio 7 moves the plugin loading path forward with async loading and CJS/ESM interop.
+
+### Async storage plugins with backward compatibility
+
+Storage plugins can now use the **promise-based async storage API**. This is an important step for plugin authors because storage backends usually talk to databases, object storage, or remote services where async code is the natural model.
+
+Verdaccio 7 keeps compatibility with existing callback/stream-based storage plugins through a thin wrapper, so current integrations should keep working while plugin authors migrate. The implementation landed in [#5933](https://github.com/verdaccio/verdaccio/pull/5933). Dedicated migration documentation is still pending.
+
+## What changes compared with 6.x?
+
+Verdaccio 7 is mostly a platform major. The user-facing registry behavior remains familiar, but the runtime and distribution model move forward:
+
+- **Verdaccio 7 runs on Node.js 24.**
+- **Verdaccio 7 uses Express 5 internally.**
+- The 7.x release branch moved to pnpm.
+- Verdaccio packages are distributed as reusable `@verdaccio/*` packages.
+- **Pure ESM plugins are supported.**
+- **Storage plugins can use the async promise-based API**, with backward compatibility for existing callback/stream-based storage plugins.
+- Logger packages were consolidated into `@verdaccio/logger`.
+- **Deprecated registry features were removed**, including star/unstar support.
+- The deprecated npm search **`/-/all` endpoint was removed**; use `/-/v1/search`.
+
+Some improvements listed in this post have already been backported to 6.x. That means they are part of Verdaccio 7, but not exclusive to Verdaccio 7.
+
+## Breaking changes to review
+
+Verdaccio 7 is a major release, so there are a few changes that operators, plugin authors, and package consumers should review before upgrading.
+
+### Node.js 24 is required
+
+**Verdaccio 7 requires Node.js 24.** If you run Verdaccio directly on a host, update the runtime before testing the new release. If you use Docker, use the Verdaccio 7 image tag and validate your deployment with the same volumes and configuration model you use in production.
+
+### Express 5 can affect middleware plugins
+
+Verdaccio uses **Express 5** internally. Custom middleware plugins should review route patterns and file-serving code. Express 5 changed wildcard route syntax, and plugins that rely on Express internals or broad catch-all routes may need small adjustments.
+
+### Config files must be YAML
+
+Verdaccio 7 accepts **YAML config files only**. JSON and JavaScript config loading has been removed. If you were using a `.json` or `.js` config file, convert it to `.yaml` or `.yml`.
+
+### Programmatic API changes
+
+The programmatic API now returns a `Promise`. If you launch Verdaccio from Node.js code, **`await runServer(...)` before calling `.listen()`**.
+
+```diff
+- const app = runServer(config);
++ const app = await runServer(config);
+  app.listen(4873);
+```
+
+The deprecated **`self_path` runtime property was also removed from the programmatic config surface**. Use `configPath` instead when reading the active config path from Verdaccio internals.
+
+### Star and unstar support was removed
+
+The registry-side **star/unstar support was removed** because npm 12 removed the client-side feature. If you had tooling around starred packages, remove that dependency before upgrading.
+
+### Deprecated `/-/all` search endpoint was removed
+
+The legacy npm search endpoint **`/-/all` was removed in Verdaccio 7**. Clients and integrations should use **`/-/v1/search`** instead.
+
+Verdaccio 6.x still keeps `/-/all` as a deprecated endpoint, but Verdaccio 7 returns `404` for it.
+
+### Plugin loading supports ESM
+
+Verdaccio 7 supports **pure ESM plugins**. Plugin authors should verify package `exports`, default exports, and async initialization behavior, especially if a plugin was previously shipped only as CommonJS or relied on legacy loading assumptions.
+
+### Storage plugin API supports async
+
+Storage plugins can use the **async promise-based storage API**. Existing callback/stream-based storage plugins are wrapped for backward compatibility, so this is intended as a migration path rather than an immediate break for existing storage plugins. There is no dedicated migration guide yet.
+
+### Deprecated AES helpers were removed
+
+The deprecated **AES encryption helper APIs were removed**. Verdaccio now uses the modern AES implementation based on `aes-256-ctr` with `createCipheriv` and `createDecipheriv`.
+
+### Logger imports changed
+
+`@verdaccio/logger-commons` and `@verdaccio/logger-prettify` were consolidated into **`@verdaccio/logger`**. Update imports if your code consumes these packages directly.
+
+## Backported to 6.x
+
+The following work is included in Verdaccio 7 and has also landed in Verdaccio 6.x:
+
+- **Package filter plugin**: [#5548](https://github.com/verdaccio/verdaccio/pull/5548), backported via [#5786](https://github.com/verdaccio/verdaccio/pull/5786), included since `verdaccio@6.4.0`
+- **Web UI login 401 handling without a Basic auth challenge**: [#5819](https://github.com/verdaccio/verdaccio/pull/5819), backported via [#5821](https://github.com/verdaccio/verdaccio/pull/5821), included since `verdaccio@6.5.2`
+- **Publish/unpublish notification hooks**: [#5920](https://github.com/verdaccio/verdaccio/pull/5920), backported via [#6020](https://github.com/verdaccio/verdaccio/pull/6020), included since `verdaccio@6.8.0`
+- **npm `/-/v1/search` endpoint hardening**: backported via [#6005](https://github.com/verdaccio/verdaccio/pull/6005), included since `verdaccio@6.8.0`
+- **Dual ESM/CJS package output**: [#5643](https://github.com/verdaccio/verdaccio/pull/5643), backported to the 6.x branch via [#6050](https://github.com/verdaccio/verdaccio/pull/6050), but not included in a published 6.x npm release yet as of `verdaccio@6.8.0`
+- **External e2e CLI workflow**: [#5678](https://github.com/verdaccio/verdaccio/pull/5678) and [#5679](https://github.com/verdaccio/verdaccio/pull/5679), backported via [#5675](https://github.com/verdaccio/verdaccio/pull/5675). This is a branch workflow change; the first 6.x npm release after it was `verdaccio@6.4.0`.
+- **Shared `@verdaccio/ui-theme` updates** for compatible Web UI fixes and improvements across 6.x and 7.x, including the UI state-management refresh ([#5563](https://github.com/verdaccio/verdaccio/pull/5563)), search UI fixes ([#5647](https://github.com/verdaccio/verdaccio/pull/5647)), JSON viewer fixes ([#5651](https://github.com/verdaccio/verdaccio/pull/5651)), and search response auto-detection ([#5801](https://github.com/verdaccio/verdaccio/pull/5801)). Verdaccio 6.x receives these through `@verdaccio/ui-theme` update PRs such as [#5794](https://github.com/verdaccio/verdaccio/pull/5794) (`verdaccio@6.5.0`, `@verdaccio/ui-theme@9.0.0-next-9.10`), [#5822](https://github.com/verdaccio/verdaccio/pull/5822) (`verdaccio@6.5.2`, `@verdaccio/ui-theme@9.0.0-next-9.14`), [#5961](https://github.com/verdaccio/verdaccio/pull/5961) (`verdaccio@6.7.3`, `@verdaccio/ui-theme@9.0.0-next-9.20`), and [#6003](https://github.com/verdaccio/verdaccio/pull/6003) (`verdaccio@6.8.0`, `@verdaccio/ui-theme@9.0.0-next-9.21`).
+
+## For plugin authors and distributions
+
+Verdaccio 7 is designed to make reuse easier. **Downstream distributions can reuse the server and CLI composition** instead of forking large parts of Verdaccio.
+
+The relevant exports include:
+
+- `@verdaccio/server`: `defineAPI(config, storage)`
+- `@verdaccio/cli`: `runCli`, `configureCli`, and command classes
+
+Verdaccio 7 also supports the **async promise-based storage API** and keeps a thin storage wrapper for callback/stream-based legacy storage plugins. Existing integrations have a clearer path forward while the core packages continue to move into the shared `@verdaccio/*` model.
+
+Verdaccio 7 also supports **pure ESM plugins**, so plugin packages can follow modern Node.js packaging without requiring a CommonJS compatibility entry point just for Verdaccio.
+
+Some plugins were relocated from the monorepo into their own repositories:
+
+- `verdaccio-active-directory`
+- `verdaccio-aws-s3-storage`, now at [verdaccio/verdaccio-aws-s3-storage](https://github.com/verdaccio/verdaccio-aws-s3-storage)
+- `verdaccio-google-cloud`, now at [verdaccio/verdaccio-google-cloud](https://github.com/verdaccio/verdaccio-google-cloud)
+
+## Technical notes
+
+### Express 5
+
+Verdaccio now runs on Express 5. Custom middleware plugins should review route wildcard usage. Express 5 uses `{*all}` syntax instead of `*`, and `req.params` may return arrays depending on the route shape.
+
+If a plugin serves files with `res.sendFile()` and absolute paths, prefer:
+
+```js
+res.sendFile(filename, { root });
+```
+
+### Build output
+
+Verdaccio 7 moved from the old Babel/esbuild build pipeline to Vite 8. Packages publish dual ESM and CJS outputs with TypeScript declarations.
+
+If you consume Verdaccio packages directly, review package `exports` and avoid unsupported deep imports.
+
+The same dual ESM/CJS output was backported to the Verdaccio 6.x branch in [#6050](https://github.com/verdaccio/verdaccio/pull/6050), where the runtime requirement is Node.js 22. As of `verdaccio@6.8.0`, that branch change is not included in a published 6.x npm release yet.
+
+### Configuration
+
+Config files are now YAML-only. Files ending in `.yaml` or `.yml` are accepted; JSON and JavaScript config loading has been removed.
+
+New server options are available:
+
+- `server.dotfiles`: controls requests to dotfile paths such as `.env` or `.git/config`. Supported values are `deny`, `ignore`, and `allow`. The default is `deny`.
+- `server.hideStaticLogs`: suppresses request logging for `/-/static/`. The default is `true`.
+
+### Logger consolidation
+
+The logger packages were consolidated. If you import from the old logger packages, update the imports:
+
+```diff
+- import { ... } from '@verdaccio/logger-commons';
+- import { ... } from '@verdaccio/logger-prettify';
++ import { ... } from '@verdaccio/logger';
+```
+
+## Thanks
+
+Thanks to everyone who contributed to the Verdaccio 7 release line and the related 6.x backports, including [@juanpicado](https://github.com/juanpicado), [@mbtools](https://github.com/mbtools), [@moglerdev](https://github.com/moglerdev), [@tmota900](https://github.com/tmota900), and [@vsugrob](https://github.com/vsugrob).
+
+You can follow the full release checklist in [Verdaccio 7 Release Notes](https://github.com/verdaccio/verdaccio/issues/5680).

--- a/website/docs/cli-registry.md
+++ b/website/docs/cli-registry.md
@@ -10,3 +10,15 @@ Setting up a private registry is quite easy on all major Package managers and ca
 - [pnpm](setup-pnpm.md)
 - [deno](setup-deno.md)
 - [bun](setup-bun.md)
+
+## Package manager compatibility {#package-manager-compatibility}
+
+Verdaccio validates package manager compatibility in a dedicated end-to-end test suite. The list of tested npm, Yarn, pnpm, Deno, and Bun versions is maintained manually by contributors so each compatibility update is explicit and reviewable.
+
+| Package manager | Setup guide | Tested versions |
+| --- | --- | --- |
+| npm | [npm](setup-npm.md) | Maintained in [verdaccio/e2e-tests](https://github.com/verdaccio/e2e-tests/blob/main/README.md) |
+| Yarn | [yarn](setup-yarn.md) | Maintained in [verdaccio/e2e-tests](https://github.com/verdaccio/e2e-tests/blob/main/README.md) |
+| pnpm | [pnpm](setup-pnpm.md) | Maintained in [verdaccio/e2e-tests](https://github.com/verdaccio/e2e-tests/blob/main/README.md) |
+| Deno | [deno](setup-deno.md) | Maintained in [verdaccio/e2e-tests](https://github.com/verdaccio/e2e-tests/blob/main/README.md) |
+| Bun | [bun](setup-bun.md) | Maintained in [verdaccio/e2e-tests](https://github.com/verdaccio/e2e-tests/blob/main/README.md) |

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -24,7 +24,13 @@ To locate the home directory, verdaccio relies on **$XDG_DATA_HOME** as a first 
 
 ## Config file format {#config-file-format}
 
-Config files should be YAML, JSON or a NodeJS module. YAML format is detected by parsing config file extension (yaml or yml, case insensitive).
+Before Verdaccio 7.x, config files could be YAML, JSON, or a Node.js module. YAML format was detected by parsing the config file extension (`.yaml` or `.yml`, case insensitive).
+
+:::warning
+
+Since Verdaccio 7.x, configuration files must be YAML only (`.yaml` or `.yml`). JSON files and Node.js module config files are no longer loaded.
+
+:::
 
 ## Default storage location {#default-storage-location}
 

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -7,11 +7,17 @@ Verdaccio is a Node.js private and proxy registry. To install it, you need a few
 
 ## Prerequisites {#prerequisites}
 
-1. **Node.js** `v18` or higher.
+1. **Node.js** `v22` or higher for Verdaccio 6.x.
+
+   :::warning
+
+   Since Verdaccio 7.x, the minimum supported runtime is **Node.js 24**.
+
+   :::
 
 2. Your favorite Node Package Manager `npm`, `pnpm` or `yarn` (classic and modern).
 
-> We highly recommend to use the latest versions of Node Package Manager clients `> npm@6.x | yarn@1.x | | yarn@2.x | pnpm@6.x`. Don't support `npm@5.x` or older.
+> We highly recommend using modern package manager clients: `npm@11` or higher, `pnpm@11` or higher, and `yarn@4` or higher. Verdaccio does not support `npm@5.x` or older.
 
 3. A modern web browser to run the web interface. We actually support `Chrome, Firefox, Edge`.
 
@@ -58,7 +64,7 @@ $> verdaccio
  info -=- local storage path /Users/user/.local/share/verdaccio/storage/.verdaccio-db.json
  info --- using htpasswd file: /Users/user/.config/verdaccio/htpasswd
  info --- http address http://localhost:4873/
- info --- version: 6.0.0
+ info --- version: 7.0.0
  info --- server started
 ```
 
@@ -113,5 +119,5 @@ docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio
 ```bash
 $ helm repo add verdaccio https://charts.verdaccio.org
 $ helm repo update
-$ helm install registry --set image.tag=6 verdaccio/verdaccio
+$ helm install registry --set image.tag=7 verdaccio/verdaccio
 ```

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -121,3 +121,5 @@ $ helm repo add verdaccio https://charts.verdaccio.org
 $ helm repo update
 $ helm install registry --set image.tag=7 verdaccio/verdaccio
 ```
+
+For a local Kubernetes setup, see the Verdaccio 7 Helm example in [docker-examples/v7/kubernetes/helm](https://github.com/verdaccio/verdaccio/tree/master/docker-examples/v7/kubernetes/helm).

--- a/website/docs/kubernetes.md
+++ b/website/docs/kubernetes.md
@@ -38,10 +38,16 @@ In this example we use `npm` as release name:
 helm install npm verdaccio/verdaccio
 ```
 
+### Run locally with Helm {#run-locally-with-helm}
+
+If you want to test Verdaccio with Helm on a local Kubernetes cluster, use the Verdaccio 7 Helm example in the repository:
+
+[docker-examples/v7/kubernetes/helm](https://github.com/verdaccio/verdaccio/tree/master/docker-examples/v7/kubernetes/helm)
+
 ### Deploy a specific version {#deploy-a-specific-version}
 
 ```bash
-helm install npm --set image.tag=3.13.1 verdaccio/verdaccio
+helm install npm --set image.tag=7 verdaccio/verdaccio
 ```
 
 ### Upgrading Verdaccio {#upgrading-verdaccio}

--- a/website/docs/node-api.md
+++ b/website/docs/node-api.md
@@ -7,7 +7,34 @@ Verdaccio can be invoked programmatically. The Node API was introduced after ver
 
 ## Usage {#usage}
 
+:::info
+
+Since Verdaccio 6.x, the recommended Node.js API is asynchronous. Use `await runServer(...)` and then call `.listen(...)` on the returned app/server.
+
+:::
+
+```js
+import { runServer } from 'verdaccio';
+
+const app = await runServer('./config/config.yaml');
+
+app.listen(4873, () => {
+  console.log('verdaccio running on http://localhost:4873');
+});
+```
+
+:::warning
+
+Since Verdaccio 7.x, the deprecated programmatic API surface was removed:
+
+- Callback-style server startup is no longer supported.
+- `config.self_path` was removed; use `config.configPath` instead.
+
+:::
+
 #### Programmatically {#programmatically}
+
+The following callback-style example is deprecated. It only applies to older Verdaccio versions and should not be used for Verdaccio 7.x.
 
 ```js
 const startServer = require("verdaccio").default;
@@ -24,7 +51,7 @@ let config = {
             url: "https://registry.npmjs.org/",
         }
     },
-    self_path: "./",
+    configPath: "./config.yaml",
     packages: {
         "@*/*": {
             access: "$all",

--- a/website/docs/notifications.md
+++ b/website/docs/notifications.md
@@ -5,8 +5,13 @@ title: 'Notifications'
 
 Notify was built primarily to use with Slack's Incoming
 webhooks, but will also deliver a simple payload to
-any endpoint. This is currently only active for the `npm publish`
-command.
+any endpoint. Notifications are available for package publish events.
+
+:::info
+
+Since Verdaccio 6.8.0, notifications can also be emitted for unpublish events.
+
+:::
 
 ## Usage {#usage}
 

--- a/website/docs/plugin-storage.md
+++ b/website/docs/plugin-storage.md
@@ -9,6 +9,12 @@ Verdaccio by default uses a file system storage plugin [local-storage](https://g
 
 ### API {#api}
 
+:::info
+
+Since Verdaccio 7.x, storage plugins can use the promise-based async storage API. Existing callback/stream-based storage plugins are detected and wrapped for backward compatibility, so legacy storage plugins can continue working while authors migrate.
+
+:::
+
 Storage plugins are composed of two objects, the `IPluginStorage<T>` and the `IPackageStorage`.
 
 - The `IPluginStorage` object handle the local database for private packages.

--- a/website/docs/plugins.md
+++ b/website/docs/plugins.md
@@ -5,6 +5,12 @@ title: 'Plugins'
 
 Verdaccio is a pluggable application. It can be extended in many ways, either new authentication methods, adding endpoints or using a custom storage.
 
+:::info
+
+Since Verdaccio 7.x, plugins can be loaded through the async plugin loading path with CommonJS and ESM interop. This allows plugin authors to publish pure ESM plugins, while existing CommonJS plugins remain supported.
+
+:::
+
 There are 5 types of plugins:
 
 - [Authentication](plugin-auth.md)

--- a/website/docs/programmatically.md
+++ b/website/docs/programmatically.md
@@ -3,26 +3,66 @@ id: verdaccio-programmatically
 title: 'Node.js API'
 ---
 
-Verdaccio is a binary command which is available in your enviroment when you install globally the package eg `npm i -g verdaccio`, but also can be dependency in your project and use it programmatically.
+Verdaccio is a binary command available in your environment when you install the package globally, for example `npm i -g verdaccio`. It can also be used as a dependency in your project through the Node.js API.
 
-### Using `fork` from `child_process` module
+### Using `spawn` from `node:child_process`
 
-Using the binary is the faster way to use verdaccio programatically, you need to add to the config file the `_debug: true` to enable the messaging system, when verdaccio is ready will send `verdaccio_started` string as message as the following example.
+Using the binary is the fastest way to run Verdaccio from another Node.js process. Prefer `spawn` with the public `verdaccio` executable instead of resolving internal package files.
 
-> If you are using ESM modules the `require` won't be available.
+The following example starts Verdaccio, waits until `/-/ping` responds, and returns a cleanup function that stops the child process.
 
 ```typescript
-export function runRegistry(args: string[] = [], childOptions: {}): Promise<ChildProcess> {
-  return new Promise((resolve, reject) => {
-    const childFork = fork(require.resolve('verdaccio/bin/verdaccio'), args, childOptions);
-    childFork.on('message', (msg: { verdaccio_started: boolean }) => {
-      if (msg.verdaccio_started) {
-        resolve(childFork);
-      }
-    });
-    childFork.on('error', (err: any) => reject([err]));
-    childFork.on('disconnect', (err: any) => reject([err]));
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+
+type VerdaccioProcess = {
+  child: ChildProcessWithoutNullStreams;
+  stop: () => Promise<void>;
+};
+
+export async function startVerdaccio(configPath: string, port = 4873): Promise<VerdaccioProcess> {
+  const controller = new AbortController();
+  const registry = `http://localhost:${port}`;
+  const child = spawn('verdaccio', ['--config', configPath, '--listen', String(port)], {
+    signal: controller.signal,
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
+  let startupError: Error | undefined;
+
+  child.once('error', (error) => {
+    startupError = error;
+  });
+
+  for (let attempt = 0; attempt < 60; attempt++) {
+    if (startupError) {
+      throw startupError;
+    }
+
+    try {
+      const response = await fetch(`${registry}/-/ping`);
+      if (response.ok) {
+        return {
+          child,
+          stop: async () => {
+            if (child.exitCode !== null) {
+              return;
+            }
+            await new Promise<void>((resolve) => {
+              child.once('exit', () => resolve());
+              controller.abort();
+            });
+          },
+        };
+      }
+    } catch {
+      // Verdaccio is still starting.
+    }
+
+    await delay(250);
+  }
+
+  controller.abort();
+  throw new Error(`Verdaccio did not start at ${registry}`);
 }
 ```
 
@@ -34,39 +74,65 @@ You can see the full example on this repository.
 
 Feature available in `v5.11.0` and higher.
 
-> Using const verdaccio = require('verdaccio'); as the default module is not encoraged, it's deprecated and recommend use `runServer` for future compability.
+:::info
+
+Since Verdaccio 6.x, the recommended API is `runServer(...)`, which can be awaited.
+
+:::
+
+:::warning
+
+Since Verdaccio 7.x, the deprecated callback-style API and `self_path` programmatic config property were removed. Use `await runServer(...)` and `configPath`.
+
+:::
+
+Using `const verdaccio = require('verdaccio');` as the default module is deprecated. Use `runServer` for future compatibility.
 
 There are three ways to use it:
 
 - No input, it will find the `config.yaml` as is you would run `verdaccio` in the console.
-- With a absolute path.
-- With an object (there is a catch here, see below).
+- With an absolute path.
+- With a config object.
 
 ```js
-const { runServer } = require('verdaccio');
-const app = await runServer(); // default configuration
-const app = await runServer('./config/config.yaml');
-const app = await runServer({ configuration });
-app.listen(4000, (event) => {
+import { runServer } from 'verdaccio';
+
+// Default configuration
+const app = await runServer();
+
+// Or a config file path
+const appWithConfigPath = await runServer('./config/config.yaml');
+
+// Or a config object
+const appWithConfigObject = await runServer({ configuration });
+
+app.listen(4000, () => {
   // do something
 });
 ```
 
-With an object you need to add `self_path`, manually (it's not nice but would be a breaking change changing it now) on v6 this is not longer need it.
+When using a config object, Verdaccio 6.x and newer can use `configPath` to identify the active configuration file.
 
 ```js
-const { runServer, parseConfigFile } = require('verdaccio');
-const configPath = join(__dirname, './config.yaml');
-const c = parseConfigFile(configPath);
-// workaround
-// on v5 the `self_path` still exists and will be removed in v6
-c.self_path = 'foo';
-runServer(c).then(() => {});
+import { parseConfigFile, runServer } from 'verdaccio';
+import { fileURLToPath } from 'node:url';
+
+const configPath = fileURLToPath(new URL('./config.yaml', import.meta.url));
+const config = parseConfigFile(configPath);
+
+config.configPath = configPath;
+
+const app = await runServer(config);
+app.listen(4000);
 ```
 
-Feature available minor than `v5.11.0`.
+For versions older than `v5.11.0`.
 
-> This is a valid way but is discoragued for future releases.
+:::warning
+
+The following API is deprecated and was removed in Verdaccio 7.x. It is kept here only for older Verdaccio versions.
+
+:::
 
 ```js
 const fs = require('fs');

--- a/website/docs/setup-npm.md
+++ b/website/docs/setup-npm.md
@@ -5,7 +5,7 @@ title: 'npm'
 
 # npm {#npm}
 
-The minimum supported NPM version is 5.
+The minimum supported npm version is 6. We recommend npm 11 or higher.
 
 ## Setting up global registry for all projects {#all}
 
@@ -33,6 +33,31 @@ or by specific scope eg: `@my-scope/auth`:
 npm config set @my-scope:registry http://localhost:4873
 ```
 
+You can also define both the private registry and the scoped registry directly in your project `.npmrc`:
+
+```ini title=".npmrc"
+registry=https://registry.npmjs.org/
+@my-company:registry=http://localhost:4873/
+```
+
+With this configuration, unscoped packages continue resolving from the public registry, while `@my-company/*` packages resolve from Verdaccio.
+
+### Minimum release age with a private scope {#minimum-release-age}
+
+npm can delay installing newly published package versions with `min-release-age`. This is useful for reducing supply-chain risk for third-party dependencies. If your private scope publishes internal packages that must be available immediately, exclude that scope from the age gate.
+
+```ini title=".npmrc"
+registry=https://registry.npmjs.org/
+@my-company:registry=http://localhost:4873/
+
+min-release-age=7
+min-release-age-exclude[]=@my-company/*
+```
+
+`min-release-age` is measured in days. Packages matching `min-release-age-exclude[]` bypass the age gate, but still use the registry configured for their scope.
+
+See also [npm config: `min-release-age`](https://docs.npmjs.com/cli/using-npm/config#min-release-age).
+
 ## Using registry only on specific command {#command}
 
 If you want one single use append `--registry http://localhost:4873/` to the required command.
@@ -58,27 +83,33 @@ If you only want to publish your package to Verdaccio but keep installing from o
 
 ## Creating user {#creating-user}
 
+:::warning
+
+Since npm 12, `npm adduser` has been removed. Use `npm login` to authenticate with an existing Verdaccio user. Create users through your Verdaccio authentication backend or use npm 11 or older if you still depend on CLI-based user creation.
+
+:::
+
 With npm 8 or below, either `adduser` or `login` are able to create users and login at the same time.
 
 ```bash
 npm adduser --registry http://localhost:4873
 ```
 
-after version `npm@9` the commands works separately:
+After version `npm@9` and before npm 12, the commands work separately:
 
 - `login` does not create users.
 
 ```bash
-npm login --registry http://localhost:4873
+npm login --registry http://localhost:4873 --auth-type=legacy
 ```
 
 - `adduser` does not login users.
 
 ```bash
-npm adduser --registry http://localhost:4873
+npm adduser --registry http://localhost:4873 --auth-type=legacy
 ```
 
-Both commands relies on web login by default, but adding `--auth-type=legacy` you can get back the previous behaviour.
+These commands rely on web login by default, but adding `--auth-type=legacy` restores the previous behavior in npm versions that still support the command.
 
 > [Web login is not supported for verdaccio.](https://github.com/verdaccio/verdaccio/issues/3413)
 
@@ -86,7 +117,11 @@ Both commands relies on web login by default, but adding `--auth-type=legacy` yo
 
 ### `npm login` with npm@9 or higher
 
-If you are running into issues login with `npm@9.x` or higher you could try use the legacy mode (see above).
+If you are running into issues logging in with `npm@9.x` or higher, try legacy mode:
+
+```bash
+npm login --registry http://localhost:4873 --auth-type=legacy
+```
 
 For progress on the native support on future you can track the following [issue#3413](https://github.com/verdaccio/verdaccio/issues/3413).
 

--- a/website/docs/setup-pnpm.md
+++ b/website/docs/setup-pnpm.md
@@ -5,12 +5,39 @@ title: 'pnpm'
 
 ### pnpm {#pnpm}
 
-> This includes 6.x or higher series.
+We recommend pnpm 11 or higher.
 
 `pnpm` recognize by default the configuration at `.npmrc` and also the `--registry` value.
 This means that you can follow the same commands described in [npm](setup-npm.md) replacing `npm` by `pnpm`.
 
-See also [pnpm Documentation - Settings - resolutionMode](https://pnpm.io/next/settings#resolutionmode).
+You can configure Verdaccio for a private scope in `.npmrc`:
+
+```ini title=".npmrc"
+registry=https://registry.npmjs.org/
+@my-company:registry=http://localhost:4873/
+```
+
+With this configuration, unscoped packages continue resolving from the public registry, while `@my-company/*` packages resolve from Verdaccio.
+
+### Minimum release age with a private scope {#minimum-release-age}
+
+pnpm can delay installing newly published package versions with `minimumReleaseAge`. In pnpm 11, the default is one day. If your private scope publishes internal packages that must be available immediately, exclude that scope from the age gate.
+
+```yaml title="pnpm-workspace.yaml"
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@my-company/*'
+```
+
+`minimumReleaseAge` is measured in minutes. Packages matching `minimumReleaseAgeExclude` bypass the age gate, but still use the registry configured for their scope.
+
+See also [pnpm settings: `minimumReleaseAge`](https://pnpm.io/settings#minimumreleaseage).
+
+### pnpm 11 command changes {#pnpm-11-command-changes}
+
+Since pnpm 11, pnpm no longer falls back to the npm CLI for commands it does not implement. Commands such as `pnpm search`, `pnpm star`, `pnpm stars`, `pnpm unstar`, `pnpm token`, `pnpm whoami`, `pnpm owner`, and `pnpm profile` now return a "not implemented" error. Use the npm CLI directly for commands that pnpm no longer supports.
+
+Other registry commands were reimplemented natively in pnpm 11, including `pnpm login`, `pnpm adduser`, `pnpm logout`, `pnpm publish`, `pnpm view`, `pnpm deprecate`, `pnpm unpublish`, and `pnpm dist-tag`.
 
 ## Troubleshooting
 

--- a/website/docs/setup-yarn.md
+++ b/website/docs/setup-yarn.md
@@ -5,6 +5,8 @@ title: 'yarn'
 
 # yarn {#yarn}
 
+We recommend Yarn 4 or higher for modern projects.
+
 #### `yarn` classic (1.x) {#yarn-classic-1x}
 
 > Be aware npm configurations are valid on the classic version
@@ -34,9 +36,8 @@ For defining a registry you must use the `.yarnrc.yml` located in the root of yo
 
 When you publish a package the `npmRegistryServer` must be used. Keep in mind the `publishConfig.registry` in the `package.json` will override this configuration.
 
-```yaml
-// .yarnrc.yml
-npmRegistryServer: "http://localhost:4873"
+```yaml title=".yarnrc.yml"
+npmRegistryServer: 'http://localhost:4873'
 
 unsafeHttpWhitelist:
   - localhost
@@ -46,9 +47,11 @@ unsafeHttpWhitelist:
 
 Using scopes is also possible and more segmented, you can define a token peer scope if is required.
 
-```
+```yaml title=".yarnrc.yml"
+npmRegistryServer: 'https://registry.npmjs.org'
+
 npmRegistries:
-  "https://registry.myverdaccio.org":
+  'https://registry.myverdaccio.org':
     npmAlwaysAuth: true
     npmAuthToken: <TOKEN>
 npmScopes:
@@ -57,11 +60,62 @@ npmScopes:
     npmPublishRegistry: https://registry.myverdaccio.org
 ```
 
-for logging via CLi use:
+With this configuration, unscoped packages continue resolving from the public registry, while `@my-company/*` packages resolve and publish through Verdaccio.
+
+### Minimum release age with a private scope {#minimum-release-age}
+
+Yarn 4.12 and newer can delay newly published package versions with `npmMinimalAgeGate`. If your private scope publishes internal packages that must be available immediately, add the scope to `npmPreapprovedPackages`.
+
+```yaml title=".yarnrc.yml"
+npmRegistryServer: 'https://registry.npmjs.org'
+
+npmMinimalAgeGate: '1d'
+npmPreapprovedPackages:
+  - '@my-company/*'
+
+npmRegistries:
+  'https://registry.myverdaccio.org':
+    npmAlwaysAuth: true
+    npmAuthToken: <TOKEN>
+npmScopes:
+  my-company:
+    npmRegistryServer: https://registry.myverdaccio.org
+    npmPublishRegistry: https://registry.myverdaccio.org
+```
+
+Packages matching `npmPreapprovedPackages` bypass Yarn package gates, but still use the registry configured for their scope.
+
+See also [Yarn security: `npmMinimalAgeGate`](https://yarnpkg.com/features/security).
+
+For logging via CLI use:
 
 ```
 yarn npm login --scope my-company
 ```
+
+### Verdaccio npm commands plugin for Yarn 4 {#verdaccio-yarn-plugin-npm}
+
+Yarn 4 does not include every npm registry command by default. Verdaccio maintains Yarn plugins for npm registry commands such as `yarn npm ping`, `yarn npm login`, `yarn npm deprecate`, `yarn npm unpublish`, `yarn npm star`, and `yarn npm unstar`.
+
+To add Verdaccio-compatible `yarn npm login` support, import the login plugin:
+
+```bash
+yarn dlx @verdaccio/yarn-import npm-login
+```
+
+Then log in to Verdaccio with the legacy auth flow:
+
+```bash
+yarn npm login --auth-type=legacy --registry http://localhost:4873
+```
+
+For a scoped registry, use the scope configured in `.yarnrc.yml`:
+
+```bash
+yarn npm login --scope my-company
+```
+
+See the plugin README for the full command list: [verdaccio/yarn-plugin-npm](https://github.com/verdaccio/yarn-plugin-npm).
 
 ## Troubleshooting {#troubleshooting}
 

--- a/website/docs/web.md
+++ b/website/docs/web.md
@@ -43,6 +43,8 @@ web:
   showSearch: true
   showDownloadTarball: true
   showRaw: true
+  # Since Verdaccio 7.x
+  assetFolder: /verdaccio/storage/assets
 ```
 
 All access restrictions defined to [protect your packages](protect-your-dependencies.md) will also apply to the Web Interface.
@@ -90,6 +92,7 @@ i18n:
 | showSearch          | boolean           | No       | true                                                          | `>=v5.10.0` | allow hide search component                                                                                                             |
 | showDownloadTarball | boolean           | No       | true                                                          | `>=v5.10.0` | allow hide download button on the sidebar                                                                                               |
 | showRaw             | boolean           | No       | true                                                          | `>=v5.10.0` | allow hide manifest button on the sidebar (experimental feature)                                                                        |
+| assetFolder         | string            | No       | `/verdaccio/storage/assets`                                   | `>=v7.0.0`  | serve custom static assets under `/-/assets/`, useful for Docker and volume-based deployments                                           |
 
 > The recommended logo size is `40x40` pixels.
 


### PR DESCRIPTION
Website documentation for the Verdaccio 7 release.

This PR updates the public website with the Verdaccio 7 release blog post and related documentation changes.

## Release rollout notes

- The Verdaccio 7 blog documents the initial rollout policy.
- Users should install with the explicit `verdaccio@7` npm tag during the initial rollout.
- The npm `latest` dist-tag will move a few days after release, after the release has had time to settle.
- Docker users should use explicit image tags such as `verdaccio/verdaccio:7` or an exact version.
- Docker `latest` is not published for this release line during the initial rollout.
- Helm users should pin the Verdaccio 7 image tag explicitly.

## Related PRs

- Verdaccio 7 release docs: https://github.com/verdaccio/verdaccio/pull/6065
- Verdaccio 7 tracking issue: https://github.com/verdaccio/verdaccio/issues/5680
- Helm chart release PR: https://github.com/verdaccio/charts/pull/198
